### PR TITLE
Fix pandoc overlay for LaTeX font fallback in Unicode PDF generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Keeps the existing archive + Docker-image extraction install flow (`.tar.zst` preferred, `.tgz` fallback)
 - **`ollama` overlay auto-dependency** — `ollama` now implicitly requires `ollama-cli`, preserving current UX (server + CLI) while separating service and CLI concerns
 
+### Fixed
+
+- **`pandoc` overlay** — `setup.sh` now writes LaTeX definitions for `\textfallback{}` in `~/.pandoc/pandoc.yaml` header includes with a guarded `\IfFontExistsTF` check for `Noto Sans Symbols 2`; fixes both XeLaTeX `Undefined control sequence` failures and hard failures when that fallback font is unavailable during Unicode PDF smoke tests (e.g. `Status icons: ✅ ⚠️ ❌`).
+
 ## [0.1.8] - 2026-04-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`pandoc` overlay** — `setup.sh` now writes LaTeX definitions for `\textfallback{}` in `~/.pandoc/pandoc.yaml` header includes with a guarded `\IfFontExistsTF` check for `Noto Sans Symbols 2`; fixes both XeLaTeX `Undefined control sequence` failures and hard failures when that fallback font is unavailable during Unicode PDF smoke tests (e.g. `Status icons: ✅ ⚠️ ❌`).
+- **`pandoc` overlay** — Unicode PDF generation no longer fails on `\textfallback{}` or when `Noto Sans Symbols 2` is unavailable, including status-icon content like `✅ ⚠️ ❌`
 
 ## [0.1.8] - 2026-04-11
 

--- a/overlays/pandoc/README.md
+++ b/overlays/pandoc/README.md
@@ -116,6 +116,16 @@ variables:
     header-includes:
         - |
             \usepackage{etoolbox}
+            \ifdefined\IfFontExistsTF
+            \IfFontExistsTF{Noto Sans Symbols 2}{%
+            \newfontfamily\textfallbackfont{Noto Sans Symbols 2}%
+            \newcommand{\textfallback}[1]{{\textfallbackfont #1}}%
+            }{%
+            \newcommand{\textfallback}[1]{#1}%
+            }
+            \else
+            \newcommand{\textfallback}[1]{#1}%
+            \fi
             \setlength{\tabcolsep}{3pt}
             \renewcommand{\arraystretch}{1.05}
             \AtBeginEnvironment{longtable}{\small}

--- a/overlays/pandoc/setup.sh
+++ b/overlays/pandoc/setup.sh
@@ -275,6 +275,16 @@ variables:
   header-includes:
     - |
       \usepackage{etoolbox}
+      \ifdefined\IfFontExistsTF
+      \IfFontExistsTF{Noto Sans Symbols 2}{%
+      \newfontfamily\textfallbackfont{Noto Sans Symbols 2}%
+      \newcommand{\textfallback}[1]{{\textfallbackfont #1}}%
+      }{%
+      \newcommand{\textfallback}[1]{#1}%
+      }
+      \else
+      \newcommand{\textfallback}[1]{#1}%
+      \fi
       \setlength{\tabcolsep}{3pt}
       \renewcommand{\arraystretch}{1.05}
       \AtBeginEnvironment{longtable}{\small}


### PR DESCRIPTION
Enhance the pandoc overlay to properly handle LaTeX font fallback for Unicode PDF generation. This change addresses XeLaTeX failures related to undefined control sequences and ensures that the fallback font is utilized correctly during document processing.