### PR TITLE
Update CHANGELOG for version 0.1.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11] - 2026-05-27
+
 ### Added
 
 - **`pi` overlay** — adds the [Pi](https://pi.dev) minimal terminal coding agent (`@earendil-works/pi-coding-agent`) with multi-provider LLM support (Anthropic, OpenAI, Gemini, DeepSeek, and more)
@@ -645,7 +647,8 @@ This version was recalled due to a packaging issue (included `.tgz` tarball). Us
 
 <!-- Links -->
 
-[Unreleased]: https://github.com/veggerby/container-superposition/compare/v0.1.10...HEAD
+[Unreleased]: https://github.com/veggerby/container-superposition/compare/v0.1.11...HEAD
+[0.1.11]: https://github.com/veggerby/container-superposition/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/veggerby/container-superposition/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/veggerby/container-superposition/compare/v0.1.8...v0.1.9
 [0.1.8]: https://github.com/veggerby/container-superposition/compare/v0.1.7...v0.1.8


### PR DESCRIPTION
Added a new version entry for 0.1.11 with details about the new 'pi' overlay feature and updated links for version comparison.