### PR TITLE
feat: Enhance publish workflow with release summary and PR comment features

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,7 @@ jobs:
         permissions:
             contents: write # Required to upload superposition.schema.json as a release asset
             id-token: write # Required for npm provenance
+            pull-requests: write # Required to comment on associated PR when release came from one
 
         steps:
             - name: Checkout code
@@ -89,6 +90,94 @@ jobs:
                   echo "Waiting for npm registry to update..."
                   sleep 10
                   npm view container-superposition@$VERSION version || echo "Package published successfully but not yet visible in registry"
+
+            - name: Add release commands to workflow summary
+              run: |
+                  VERSION=${{ steps.version.outputs.version }}
+                  {
+                    echo '## 🚀 Release published to npm'
+                    echo
+                    echo "Version: \`$VERSION\`"
+                    echo
+                    echo 'Install exact version:'
+                    echo
+                    echo '```bash'
+                    echo "npm install container-superposition@$VERSION"
+                    echo '```'
+                    echo
+                    echo 'Run directly:'
+                    echo
+                    echo '```bash'
+                    echo "npx container-superposition@$VERSION regen"
+                    echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Resolve released tag commit
+              id: release-commit
+              run: |
+                  SHA=$(git rev-list -n 1 "${GITHUB_REF_NAME}")
+                  echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+
+            - name: Comment on associated PR with release version
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const version = '${{ steps.version.outputs.version }}';
+                      const releaseCommitSha = '${{ steps.release-commit.outputs.sha }}';
+                      const body = [
+                        '## 🚀 Release published to npm',
+                        '',
+                        'A final release version has been published from this PR:',
+                        '',
+                        '```',
+                        `npm install container-superposition@${version}`,
+                        '```',
+                        '',
+                        'Or run directly:',
+                        '',
+                        '```',
+                        `npx container-superposition@${version} regen`,
+                        '```',
+                      ].join('\n');
+
+                      const { data: pulls } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        commit_sha: releaseCommitSha,
+                      });
+
+                      const pr = pulls.find((candidate) => candidate.merged_at) ?? pulls[0];
+                      if (!pr) {
+                        core.info(`No associated PR found for release commit ${releaseCommitSha}; skipping PR comment.`);
+                        return;
+                      }
+
+                      const { data: comments } = await github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: pr.number,
+                      });
+
+                      const existing = comments.find((c) =>
+                        c.user.login === 'github-actions[bot]' &&
+                        c.body.includes('## 🚀 Release published to npm')
+                      );
+
+                      if (existing) {
+                        await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: existing.id,
+                          body,
+                        });
+                      } else {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: pr.number,
+                          body,
+                        });
+                      }
 
     publish-prerelease:
         runs-on: ubuntu-latest
@@ -158,6 +247,34 @@ jobs:
 
             - name: Publish prerelease to npm
               run: npm publish --provenance --access public --tag pr-${{ github.event.pull_request.number }}
+
+            - name: Add prerelease commands to workflow summary
+              run: |
+                  VERSION=${{ steps.version.outputs.version }}
+                  PR_NUMBER=${{ github.event.pull_request.number }}
+                  {
+                    echo '## 📦 Prerelease published to npm'
+                    echo
+                    echo "Version: \`$VERSION\`"
+                    echo
+                    echo 'Install exact version:'
+                    echo
+                    echo '```bash'
+                    echo "npm install container-superposition@$VERSION"
+                    echo '```'
+                    echo
+                    echo 'Run directly:'
+                    echo
+                    echo '```bash'
+                    echo "npx container-superposition@$VERSION regen"
+                    echo '```'
+                    echo
+                    echo 'PR dist-tag:'
+                    echo
+                    echo '```bash'
+                    echo "npm install container-superposition@pr-$PR_NUMBER"
+                    echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
 
             - name: Comment on PR with prerelease version
               uses: actions/github-script@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Publish workflow release guidance** — successful npm publish runs now render exact `npm install` and `npx container-superposition@<version> regen` commands in the workflow summary; prerelease runs do same, and final releases also comment on associated PRs when one is found
+
 - **Console output for unlisted parameters** — the `⚠️  Unknown overlay parameters …` warning
   (yellow, comma-separated) is replaced by a neutral `⚙️  Project-only parameters (not declared
 by any selected overlay):` informational block using the same `KEY=VALUE` per-line format as

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -68,12 +68,16 @@ Publishing is **automated via GitHub Actions** when a new release is created.
     - ✅ Verify package contents
     - ✅ Publish to npm with provenance
     - ✅ Verify publication
+    - ✅ Render exact `npm install` and `npx container-superposition@<version> regen` commands in the workflow run summary
+    - ✅ Comment on associated PR with final release commands when the release commit is linked to a PR
 
 ### PR prereleases
 
 Ready for Review PRs publish npm prereleases automatically.
 
 Draft PRs skip prerelease publishing unless labeled `publish-prerelease`. Add `publish-prerelease` to a Draft PR when reviewers need an npm prerelease before the PR is ready. Remove `publish-prerelease` to stop future Draft PR prereleases, or convert a PR to Draft without that label to skip future Draft prerelease publishes.
+
+Successful prerelease runs also render exact `npm install` and `npx container-superposition@<version> regen` commands in the workflow run summary. PR-triggered prerelease publishes still create or update the PR comment with the same runnable commands.
 
 The label does not affect final releases, mergeability, or npm `latest`. Maintainers may create the repository label with this description: `Publish npm prereleases for this PR, including while draft`.
 

--- a/docs/specs/028-publish-summaries-and-pr-comments/spec.md
+++ b/docs/specs/028-publish-summaries-and-pr-comments/spec.md
@@ -1,0 +1,129 @@
+# Feature Specification: Publish Workflow Summaries and PR Comment Parity
+
+**Spec ID**: `028-publish-summaries-and-pr-comments`
+**Taxonomy**: `INFRA-BUILD`
+**Created**: 2026-06-08
+**Author**: PM Agent
+**Status**: Implemented
+**Input**: On publish, show install / npx commands in workflow output itself, not only prerelease PR comment. Keep PR comment behavior when a PR exists.
+
+## Problem Statement
+
+Current publish automation exposes runnable npm / npx commands only in prerelease PR comments. Final release publishes do not surface the same commands in workflow-rendered output, so maintainers must infer what to run or inspect package docs.
+
+Maintainers want publish runs themselves to render exact install / `npx` commands, and they also want PR comments when there is an associated PR.
+
+## Goals
+
+- Render exact install and `npx` usage commands in GitHub Actions workflow output for successful final releases
+- Render same kind of command summary in successful prerelease runs
+- Preserve prerelease PR comment behavior for PR-triggered prerelease publishes
+- Add final release PR comment behavior when a published release can be associated with a PR
+- Keep publish versioning, npm tags, and release trigger semantics unchanged
+- Add workflow regression coverage for summary/comment steps
+- Add changelog entry under `Unreleased`
+
+## Non-Goals
+
+- Changing release or prerelease version formats
+- Changing npm dist-tag behavior
+- Commenting on issues not tied to PRs
+- Adding manual publish workflows
+- Changing package runtime behavior
+
+## Proposed Behavior
+
+### Workflow run summaries
+
+After successful npm publish:
+
+- `publish` writes a Markdown summary to `$GITHUB_STEP_SUMMARY`
+- `publish-prerelease` writes a Markdown summary to `$GITHUB_STEP_SUMMARY`
+
+Summary content must include:
+
+- published version
+- `npm install` command using exact version
+- `npx container-superposition@<version> regen` command
+
+Prerelease summary may also include PR dist-tag guidance if useful, but exact-version commands are required.
+
+### PR comments
+
+#### Prerelease job
+
+Existing prerelease PR comment remains:
+
+- heading remains `## 📦 Prerelease published to npm`
+- existing bot comment is updated rather than duplicated
+- comment continues to include install and `npx ... regen` commands
+
+#### Final release job
+
+After successful final release publish:
+
+- workflow attempts to find PR associated with released commit/tag
+- if associated PR found, create or update bot comment on that PR
+- if no associated PR found, skip comment silently
+
+Release PR comment should:
+
+- use distinct heading, e.g. `## 🚀 Release published to npm`
+- include published exact version
+- include exact-version `npm install` and `npx ... regen` commands
+- update existing matching bot comment rather than duplicate it
+
+### Permissions
+
+`publish` job may add comment-capable permission only as needed for release PR comments. Other permissions remain unchanged.
+
+### Documentation
+
+Update `docs/publishing.md` to state:
+
+- successful publish runs render install / `npx` commands in workflow summary
+- prerelease PRs still receive PR comments
+- final release publishes comment on associated PR when one is found
+
+## Technical Design
+
+### Ownership
+
+- `.github/workflows/publish.yml` owns publish summaries and PR comments
+- `tool/__tests__/publish-workflow.test.ts` owns static workflow regression checks
+- `docs/publishing.md` owns maintainer-facing explanation
+- `CHANGELOG.md` owns user-visible note
+
+### Suggested workflow slices
+
+1. Add release summary step after successful final publish
+2. Add prerelease summary step after successful prerelease publish
+3. Add release PR comment step after final publish, using associated-PR lookup
+4. Extend static tests for new summary/comment contracts
+5. Update docs and changelog
+
+## Acceptance Criteria
+
+1. [x] `publish` writes rendered workflow summary containing exact-version `npm install` and `npx container-superposition@<version> regen`
+2. [x] `publish-prerelease` writes rendered workflow summary containing exact-version `npm install` and `npx container-superposition@<version> regen`
+3. [x] existing prerelease PR comment behavior remains in `publish-prerelease`
+4. [x] `publish` attempts PR comment only after successful final publish
+5. [x] final release PR comment is skipped without failure when no associated PR exists
+6. [x] final release PR comment updates existing matching bot comment rather than duplicating it
+7. [x] workflow regression tests cover summary steps and release comment step placement
+8. [x] `docs/publishing.md` documents workflow summary + PR comment behavior
+9. [x] `CHANGELOG.md` includes `Unreleased` entry for publish summary / PR comment behavior
+
+## Architecture Decision Impact
+
+Aligned with current repository architecture. Change stays inside release automation, docs, changelog, and workflow tests. No ADR needed.
+
+## Routing Decision
+
+PM → Developer
+
+## Implementation Notes
+
+Implemented 2026-06-08. Updated `.github/workflows/publish.yml` so both `publish` and `publish-prerelease` write runnable install / `npx ... regen` commands to `$GITHUB_STEP_SUMMARY`. Added final-release associated-PR comment behavior in `publish` using release-tag commit → associated PR lookup, while preserving prerelease PR comments. Extended `tool/__tests__/publish-workflow.test.ts` to assert summary/comment step placement and updated `docs/publishing.md` plus `CHANGELOG.md`.
+
+Validation: `npm run lint`, `npm test -- tool/__tests__/publish-workflow.test.ts`.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,31 +1,32 @@
 # Specs Index
 
-| Spec                                                                                         | Title                                                             | Status   | Taxonomy             |
-| -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | -------- | -------------------- |
-| [001-verbose-plan-graph](001-verbose-plan-graph/spec.md)                                     | Verbose Plan Graph                                                | Final    | CLI-UX               |
-| [002-superposition-config-file](002-superposition-config-file/spec.md)                       | Project Configuration File                                        | Final    | PROJECT              |
-| [003-mkdocs2-overlay](003-mkdocs2-overlay/spec.md)                                           | MkDocs 2.x Overlay                                                | Final    | OVERLAY-NEW          |
-| [004-doctor-fix](004-doctor-fix/spec.md)                                                     | `doctor --fix` — Interactive Auto-Repair                          | Final    | CLI-COMMAND          |
-| [005-cuda-overlay](005-cuda-overlay/spec.md)                                                 | CUDA (NVIDIA GPU) Overlay                                         | Final    | OVERLAY-NEW          |
-| [006-rocm-overlay](006-rocm-overlay/spec.md)                                                 | ROCm (AMD GPU) Overlay                                            | Final    | OVERLAY-NEW          |
-| [007-target-aware-generation](007-target-aware-generation/spec.md)                           | Target-Aware Generation                                           | Final    | CLI-FLAG             |
-| [008-project-file-canonical](008-project-file-canonical/spec.md)                             | Make superposition.yml Canonical Input                            | Approved | PROJECT              |
-| [009-project-env](009-project-env/spec.md)                                                   | Unified Project-Level Environment Variables                       | Approved | PROJECT              |
-| [010-compose-env-materialization](010-compose-env-materialization/spec.md)                   | Compose Env Materialization and Env Template Naming               | Approved | COMPOSER-FEAT        |
-| [011-overlay-parameters](011-overlay-parameters/spec.md)                                     | Overlay Parameters with Safe Substitution                         | Final    | SCHEMA-FIELD         |
-| [012-ollama-cli-overlay](012-ollama-cli-overlay/spec.md)                                     | Split Ollama Service and CLI Overlays                             | Final    | OVERLAY-NEW          |
-| [013-doctor-dependency-check](013-doctor-dependency-check/spec.md)                           | Doctor Overlay Dependency Resolution Check                        | Approved | CLI-UX               |
-| [014-doctor-compose-port-cross-validation](014-doctor-compose-port-cross-validation/spec.md) | Doctor Compose / Port Cross-Validation                            | Approved | CLI-UX               |
-| [015-doctor-env-example-drift](015-doctor-env-example-drift/spec.md)                         | Doctor `.env.example` Drift Detection                             | Approved | CLI-UX               |
-| [016-doctor-reproducibility-check](016-doctor-reproducibility-check/spec.md)                 | Doctor Reproducibility Check                                      | Approved | CLI-UX               |
-| [017-doctor-dry-run](017-doctor-dry-run/spec.md)                                             | Doctor `--fix --dry-run` Flag                                     | Approved | CLI-FLAG             |
-| [018-init-project-file](018-init-project-file/spec.md)                                       | `init --project-file`                                             | Final    | PROJECT              |
-| [019-project-mounts](019-project-mounts/spec.md)                                             | First-Class Mounts Support                                        | Approved | PROJECT              |
-| [020-superposition-yml-schema](020-superposition-yml-schema/spec.md)                         | JSON Schema for `superposition.yml`                               | Approved | SCHEMA-FIELD         |
-| [021-deterministic-generated-readme](021-deterministic-generated-readme/spec.md)             | Deterministic Generated README Header                             | Approved | CLI-UX               |
-| [022-local-superposition-config](022-local-superposition-config/spec.md)                     | Local Superposition Config                                        | Final    | PROJECT              |
-| [023-pr-prerelease-gate](023-pr-prerelease-gate/spec.md)                                     | PR Prerelease Deployment Gate                                     | Final    | INFRA-BUILD          |
-| [024-project-ports](024-project-ports/spec.md)                                               | Project-Level `ports` Field (plain/compose redesign)              | Final    | SCHEMA-FIELD         |
-| [025-variable-expansion-consolidation](025-variable-expansion-consolidation/spec.md)         | Variable Expansion and Substitution Consolidation                 | Final    | SCHEMA-FIELD, CLI-UX |
-| [026-adhoc-project-parameters](026-adhoc-project-parameters/spec.md)                         | Ad-hoc Project Parameters                                         | Final    | SCHEMA-FIELD, CLI-UX |
-| [027-devcontainer-gitignore-content](027-devcontainer-gitignore-content/spec.md)             | devcontainerGitignore — Drop `!.gitignore` from Generated Content | Final    | CLI-UX               |
+| Spec                                                                                         | Title                                                             | Status      | Taxonomy             |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ----------- | -------------------- |
+| [001-verbose-plan-graph](001-verbose-plan-graph/spec.md)                                     | Verbose Plan Graph                                                | Final       | CLI-UX               |
+| [002-superposition-config-file](002-superposition-config-file/spec.md)                       | Project Configuration File                                        | Final       | PROJECT              |
+| [003-mkdocs2-overlay](003-mkdocs2-overlay/spec.md)                                           | MkDocs 2.x Overlay                                                | Final       | OVERLAY-NEW          |
+| [004-doctor-fix](004-doctor-fix/spec.md)                                                     | `doctor --fix` — Interactive Auto-Repair                          | Final       | CLI-COMMAND          |
+| [005-cuda-overlay](005-cuda-overlay/spec.md)                                                 | CUDA (NVIDIA GPU) Overlay                                         | Final       | OVERLAY-NEW          |
+| [006-rocm-overlay](006-rocm-overlay/spec.md)                                                 | ROCm (AMD GPU) Overlay                                            | Final       | OVERLAY-NEW          |
+| [007-target-aware-generation](007-target-aware-generation/spec.md)                           | Target-Aware Generation                                           | Final       | CLI-FLAG             |
+| [008-project-file-canonical](008-project-file-canonical/spec.md)                             | Make superposition.yml Canonical Input                            | Approved    | PROJECT              |
+| [009-project-env](009-project-env/spec.md)                                                   | Unified Project-Level Environment Variables                       | Approved    | PROJECT              |
+| [010-compose-env-materialization](010-compose-env-materialization/spec.md)                   | Compose Env Materialization and Env Template Naming               | Approved    | COMPOSER-FEAT        |
+| [011-overlay-parameters](011-overlay-parameters/spec.md)                                     | Overlay Parameters with Safe Substitution                         | Final       | SCHEMA-FIELD         |
+| [012-ollama-cli-overlay](012-ollama-cli-overlay/spec.md)                                     | Split Ollama Service and CLI Overlays                             | Final       | OVERLAY-NEW          |
+| [013-doctor-dependency-check](013-doctor-dependency-check/spec.md)                           | Doctor Overlay Dependency Resolution Check                        | Approved    | CLI-UX               |
+| [014-doctor-compose-port-cross-validation](014-doctor-compose-port-cross-validation/spec.md) | Doctor Compose / Port Cross-Validation                            | Approved    | CLI-UX               |
+| [015-doctor-env-example-drift](015-doctor-env-example-drift/spec.md)                         | Doctor `.env.example` Drift Detection                             | Approved    | CLI-UX               |
+| [016-doctor-reproducibility-check](016-doctor-reproducibility-check/spec.md)                 | Doctor Reproducibility Check                                      | Approved    | CLI-UX               |
+| [017-doctor-dry-run](017-doctor-dry-run/spec.md)                                             | Doctor `--fix --dry-run` Flag                                     | Approved    | CLI-FLAG             |
+| [018-init-project-file](018-init-project-file/spec.md)                                       | `init --project-file`                                             | Final       | PROJECT              |
+| [019-project-mounts](019-project-mounts/spec.md)                                             | First-Class Mounts Support                                        | Approved    | PROJECT              |
+| [020-superposition-yml-schema](020-superposition-yml-schema/spec.md)                         | JSON Schema for `superposition.yml`                               | Approved    | SCHEMA-FIELD         |
+| [021-deterministic-generated-readme](021-deterministic-generated-readme/spec.md)             | Deterministic Generated README Header                             | Approved    | CLI-UX               |
+| [022-local-superposition-config](022-local-superposition-config/spec.md)                     | Local Superposition Config                                        | Final       | PROJECT              |
+| [023-pr-prerelease-gate](023-pr-prerelease-gate/spec.md)                                     | PR Prerelease Deployment Gate                                     | Final       | INFRA-BUILD          |
+| [024-project-ports](024-project-ports/spec.md)                                               | Project-Level `ports` Field (plain/compose redesign)              | Final       | SCHEMA-FIELD         |
+| [025-variable-expansion-consolidation](025-variable-expansion-consolidation/spec.md)         | Variable Expansion and Substitution Consolidation                 | Final       | SCHEMA-FIELD, CLI-UX |
+| [026-adhoc-project-parameters](026-adhoc-project-parameters/spec.md)                         | Ad-hoc Project Parameters                                         | Final       | SCHEMA-FIELD, CLI-UX |
+| [027-devcontainer-gitignore-content](027-devcontainer-gitignore-content/spec.md)             | devcontainerGitignore — Drop `!.gitignore` from Generated Content | Final       | CLI-UX               |
+| [028-publish-summaries-and-pr-comments](028-publish-summaries-and-pr-comments/spec.md)       | Publish Workflow Summaries and PR Comment Parity                  | Implemented | INFRA-BUILD          |

--- a/tool/__tests__/publish-workflow.test.ts
+++ b/tool/__tests__/publish-workflow.test.ts
@@ -58,7 +58,31 @@ describe('publish workflow prerelease gate', () => {
         expect(workflow.jobs.publish.if).toContain("startsWith(github.ref, 'refs/tags/v')");
     });
 
-    it('gates publish-prerelease before publish and comment steps', () => {
+    it('keeps release summary and release PR comment steps in publish job', () => {
+        const { workflow } = loadWorkflow();
+        const releaseJob = workflow.jobs.publish;
+
+        expect(releaseJob.permissions).toEqual({
+            contents: 'write',
+            'id-token': 'write',
+            'pull-requests': 'write',
+        });
+
+        const releaseStepNames = releaseJob.steps?.map((step) => step.name ?? '') ?? [];
+        expect(releaseStepNames).toContain('Publish to npm');
+        expect(releaseStepNames).toContain('Add release commands to workflow summary');
+        expect(releaseStepNames).toContain('Comment on associated PR with release version');
+
+        const publishIndex = releaseStepNames.indexOf('Publish to npm');
+        const summaryIndex = releaseStepNames.indexOf('Add release commands to workflow summary');
+        const commentIndex = releaseStepNames.indexOf(
+            'Comment on associated PR with release version'
+        );
+        expect(summaryIndex).toBeGreaterThan(publishIndex);
+        expect(commentIndex).toBeGreaterThan(publishIndex);
+    });
+
+    it('gates publish-prerelease before publish, summary, and comment steps', () => {
         const { workflow } = loadWorkflow();
         const prereleaseJob = workflow.jobs['publish-prerelease'];
 
@@ -75,14 +99,28 @@ describe('publish workflow prerelease gate', () => {
 
         const prereleaseStepNames = prereleaseJob.steps?.map((step) => step.name ?? '') ?? [];
         expect(prereleaseStepNames).toContain('Publish prerelease to npm');
+        expect(prereleaseStepNames).toContain('Add prerelease commands to workflow summary');
         expect(prereleaseStepNames).toContain('Comment on PR with prerelease version');
         expect(prereleaseStepNames.some((name) => name.toLowerCase().includes('skip'))).toBe(false);
 
+        const publishIndex = prereleaseStepNames.indexOf('Publish prerelease to npm');
+        const summaryIndex = prereleaseStepNames.indexOf(
+            'Add prerelease commands to workflow summary'
+        );
+        const commentIndex = prereleaseStepNames.indexOf('Comment on PR with prerelease version');
+        expect(summaryIndex).toBeGreaterThan(publishIndex);
+        expect(commentIndex).toBeGreaterThan(publishIndex);
+
         const allJobs = Object.entries(workflow.jobs);
-        const commentJobs = allJobs.filter(([, job]) =>
+        const prereleaseCommentJobs = allJobs.filter(([, job]) =>
             job.steps?.some((step) => step.name === 'Comment on PR with prerelease version')
         );
-        expect(commentJobs.map(([name]) => name)).toEqual(['publish-prerelease']);
+        expect(prereleaseCommentJobs.map(([name]) => name)).toEqual(['publish-prerelease']);
+
+        const releaseCommentJobs = allJobs.filter(([, job]) =>
+            job.steps?.some((step) => step.name === 'Comment on associated PR with release version')
+        );
+        expect(releaseCommentJobs.map(([name]) => name)).toEqual(['publish']);
     });
 
     it.each([


### PR DESCRIPTION
Improve the publish workflow by rendering exact `npm install` and `npx` commands in the workflow summary for both final releases and prereleases. Add functionality to comment on associated PRs during final releases while preserving existing prerelease comment behavior. Update documentation and tests to reflect these changes.