### PR TITLE
fix(overlay): Fix git-helpers overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ superposition.json.backup-*
 
 # container-superposition local config
 superposition.local.yml
+token-usage.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`git-helpers` GitHub credential helper path** — generated containers now replace broken host-specific `gh auth git-credential` helper paths (for example `/home/linuxbrew/.linuxbrew/bin/gh`) with portable `!gh auth git-credential`, fixing `git push` failures when host Homebrew paths do not exist inside container
-
-### Fixed
-
-- **`git-helpers` overlay repairs stale host GitHub CLI credential helpers** — setup now removes inherited `/home/linuxbrew/.linuxbrew/bin/gh auth git-credential` entries from global Git config inside container and adds `!gh auth git-credential`, so `git push` works when host `.gitconfig` points at a non-container `gh` binary.
+- **`git-helpers` GitHub credential helper path** — setup now removes inherited host-specific `gh auth git-credential` helper entries (for example `!/home/linuxbrew/.linuxbrew/bin/gh auth git-credential`) and adds portable `!gh auth git-credential`, fixing `git push` failures when host paths do not exist inside the container
 
 ## [0.1.12] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`git-helpers` GitHub credential helper path** — generated containers now replace broken host-specific `gh auth git-credential` helper paths (for example `/home/linuxbrew/.linuxbrew/bin/gh`) with portable `!gh auth git-credential`, fixing `git push` failures when host Homebrew paths do not exist inside container
+
+### Fixed
+
+- **`git-helpers` overlay repairs stale host GitHub CLI credential helpers** — setup now removes inherited `/home/linuxbrew/.linuxbrew/bin/gh auth git-credential` entries from global Git config inside container and adds `!gh auth git-credential`, so `git push` works when host `.gitconfig` points at a non-container `gh` binary.
+
 ## [0.1.12] - 2026-06-09
 
 ### Fixed

--- a/docs/opportunities/README.md
+++ b/docs/opportunities/README.md
@@ -1,0 +1,88 @@
+# Opportunity Backlog
+
+Last updated: 2026-06-22
+
+## Prioritized
+
+### 1. Discovery surface clarity and docs alignment
+- **type**: UX
+- **status**: prioritized
+- **value summary**: Reduce first-run confusion and failed self-service discovery by making available overlays easier to find and current workflows easier to follow.
+- **urgency**: High
+- **confidence**: High
+- **rough effort/risk**: Low–Medium effort, Low risk
+- **evidence**:
+  - Default `list` output omits `messaging` category despite 3 live messaging overlays.
+  - `list --category messaging` and other filtered tables render many ports as `[object Object]`.
+  - User docs still show deprecated patterns such as category-centric project config (`language:` / `database:`), old CLI examples (`--postgres`, `cs list --presets`), and `_serviceOrder` references.
+  - `plan --diff` exists in CLI/help/tests but is lightly surfaced in docs.
+- **recommended next prompt or owner**: Spec captured in `docs/specs/030-discovery-surface-and-docs-alignment/spec.md`.
+
+### 2. Versioned private overlay and preset catalogs
+- **type**: feature
+- **status**: candidate
+- **value summary**: Unlock platform-team adoption by letting orgs publish and pin private catalogs without forking tool.
+- **urgency**: Medium
+- **confidence**: Medium
+- **rough effort/risk**: High effort, High architecture/security risk
+- **evidence**:
+  - Draft spec exists: `docs/specs/029-versioned-private-catalogs/spec.md`.
+  - Opportunity aligns with platform/team workflow expansion and reproducible pinned project config model.
+  - Spec now includes technical-design and routing closure for implementation handoff.
+- **recommended next prompt or owner**: Spec captured in `docs/specs/029-versioned-private-catalogs/spec.md`.
+
+### 3. Command and doc model simplification sweep
+- **type**: documentation
+- **status**: candidate
+- **value summary**: Lower learning cost by aligning README/docs/help/examples around one canonical mental model: `superposition.yml` + flat `overlays:` + discovery commands.
+- **urgency**: High
+- **confidence**: High
+- **rough effort/risk**: Medium effort, Low risk
+- **evidence**:
+  - `README.md` quickstart still shows category-based project file fields.
+  - `tool/README.md`, `docs/quick-reference.md`, `docs/examples.md`, `docs/team-workflow.md`, `docs/messaging-quick-start.md`, `docs/creating-overlays.md`, `docs/dependencies.md` contain stale CLI/config guidance.
+- **recommended next prompt or owner**: Covered by `docs/specs/030-discovery-surface-and-docs-alignment/spec.md`.
+
+### 4. Preset-led onboarding for common jobs-to-be-done
+- **type**: feature
+- **status**: candidate
+- **value summary**: Increase successful first-run setup by steering users toward opinionated presets instead of large overlay catalogs.
+- **urgency**: Medium
+- **confidence**: Medium
+- **rough effort/risk**: Medium effort, Medium risk
+- **evidence**:
+  - 94 catalog items create high choice load.
+  - 13 presets already exist for common scenarios (`frontend`, `web-api`, `microservice`, `local-llm`, etc.).
+  - Docs emphasize composability, but preset-first guidance appears secondary in some entrypoints.
+- **recommended next prompt or owner**: Spec captured in `docs/specs/031-preset-led-onboarding-for-common-jobs/spec.md`.
+
+### 5. Power-user planning workflow visibility
+- **type**: UX
+- **status**: candidate
+- **value summary**: Improve confidence before generation by surfacing `plan`, `--verbose`, and `--diff` as safer preview workflow.
+- **urgency**: Medium
+- **confidence**: Medium
+- **rough effort/risk**: Low effort, Low risk
+- **evidence**:
+  - `plan --diff` fully exists in CLI/help/tests.
+  - Main docs center `init`/`regen`; preview workflow less prominent.
+- **recommended next prompt or owner**: Covered by `docs/specs/030-discovery-surface-and-docs-alignment/spec.md`.
+
+## Horizon buckets
+
+### Quick wins
+1. Discovery surface clarity and docs alignment
+2. Command and doc model simplification sweep
+3. Power-user planning workflow visibility
+
+### Next big bets
+1. Versioned private overlay and preset catalogs
+2. Preset-led onboarding for common jobs-to-be-done
+
+### Longer-term options
+- Catalog version upgrade assistant after private catalogs foundation exists
+- Usage analytics or feedback loops to validate preset/discovery effectiveness
+
+## Notes
+- Ranking based on repository evidence only. No telemetry, issue volume, or conversion data reviewed.
+- Quick-win items likely compound together and may be worth bundling into one user-facing discovery/onboarding initiative.

--- a/docs/opportunities/README.md
+++ b/docs/opportunities/README.md
@@ -5,6 +5,7 @@ Last updated: 2026-06-22
 ## Prioritized
 
 ### 1. Discovery surface clarity and docs alignment
+
 - **type**: UX
 - **status**: prioritized
 - **value summary**: Reduce first-run confusion and failed self-service discovery by making available overlays easier to find and current workflows easier to follow.
@@ -12,13 +13,14 @@ Last updated: 2026-06-22
 - **confidence**: High
 - **rough effort/risk**: Low–Medium effort, Low risk
 - **evidence**:
-  - Default `list` output omits `messaging` category despite 3 live messaging overlays.
-  - `list --category messaging` and other filtered tables render many ports as `[object Object]`.
-  - User docs still show deprecated patterns such as category-centric project config (`language:` / `database:`), old CLI examples (`--postgres`, `cs list --presets`), and `_serviceOrder` references.
-  - `plan --diff` exists in CLI/help/tests but is lightly surfaced in docs.
+    - Default `list` output omits `messaging` category despite 3 live messaging overlays.
+    - `list --category messaging` and other filtered tables render many ports as `[object Object]`.
+    - User docs still show deprecated patterns such as category-centric project config (`language:` / `database:`), old CLI examples (`--postgres`, `cs list --presets`), and `_serviceOrder` references.
+    - `plan --diff` exists in CLI/help/tests but is lightly surfaced in docs.
 - **recommended next prompt or owner**: Spec captured in `docs/specs/030-discovery-surface-and-docs-alignment/spec.md`.
 
 ### 2. Versioned private overlay and preset catalogs
+
 - **type**: feature
 - **status**: candidate
 - **value summary**: Unlock platform-team adoption by letting orgs publish and pin private catalogs without forking tool.
@@ -26,12 +28,13 @@ Last updated: 2026-06-22
 - **confidence**: Medium
 - **rough effort/risk**: High effort, High architecture/security risk
 - **evidence**:
-  - Draft spec exists: `docs/specs/029-versioned-private-catalogs/spec.md`.
-  - Opportunity aligns with platform/team workflow expansion and reproducible pinned project config model.
-  - Spec now includes technical-design and routing closure for implementation handoff.
+    - Draft spec exists: `docs/specs/029-versioned-private-catalogs/spec.md`.
+    - Opportunity aligns with platform/team workflow expansion and reproducible pinned project config model.
+    - Spec now includes technical-design and routing closure for implementation handoff.
 - **recommended next prompt or owner**: Spec captured in `docs/specs/029-versioned-private-catalogs/spec.md`.
 
 ### 3. Command and doc model simplification sweep
+
 - **type**: documentation
 - **status**: candidate
 - **value summary**: Lower learning cost by aligning README/docs/help/examples around one canonical mental model: `superposition.yml` + flat `overlays:` + discovery commands.
@@ -39,11 +42,12 @@ Last updated: 2026-06-22
 - **confidence**: High
 - **rough effort/risk**: Medium effort, Low risk
 - **evidence**:
-  - `README.md` quickstart still shows category-based project file fields.
-  - `tool/README.md`, `docs/quick-reference.md`, `docs/examples.md`, `docs/team-workflow.md`, `docs/messaging-quick-start.md`, `docs/creating-overlays.md`, `docs/dependencies.md` contain stale CLI/config guidance.
+    - `README.md` quickstart still shows category-based project file fields.
+    - `tool/README.md`, `docs/quick-reference.md`, `docs/examples.md`, `docs/team-workflow.md`, `docs/messaging-quick-start.md`, `docs/creating-overlays.md`, `docs/dependencies.md` contain stale CLI/config guidance.
 - **recommended next prompt or owner**: Covered by `docs/specs/030-discovery-surface-and-docs-alignment/spec.md`.
 
 ### 4. Preset-led onboarding for common jobs-to-be-done
+
 - **type**: feature
 - **status**: candidate
 - **value summary**: Increase successful first-run setup by steering users toward opinionated presets instead of large overlay catalogs.
@@ -51,12 +55,13 @@ Last updated: 2026-06-22
 - **confidence**: Medium
 - **rough effort/risk**: Medium effort, Medium risk
 - **evidence**:
-  - 94 catalog items create high choice load.
-  - 13 presets already exist for common scenarios (`frontend`, `web-api`, `microservice`, `local-llm`, etc.).
-  - Docs emphasize composability, but preset-first guidance appears secondary in some entrypoints.
+    - 94 catalog items create high choice load.
+    - 13 presets already exist for common scenarios (`frontend`, `web-api`, `microservice`, `local-llm`, etc.).
+    - Docs emphasize composability, but preset-first guidance appears secondary in some entrypoints.
 - **recommended next prompt or owner**: Spec captured in `docs/specs/031-preset-led-onboarding-for-common-jobs/spec.md`.
 
 ### 5. Power-user planning workflow visibility
+
 - **type**: UX
 - **status**: candidate
 - **value summary**: Improve confidence before generation by surfacing `plan`, `--verbose`, and `--diff` as safer preview workflow.
@@ -64,25 +69,29 @@ Last updated: 2026-06-22
 - **confidence**: Medium
 - **rough effort/risk**: Low effort, Low risk
 - **evidence**:
-  - `plan --diff` fully exists in CLI/help/tests.
-  - Main docs center `init`/`regen`; preview workflow less prominent.
+    - `plan --diff` fully exists in CLI/help/tests.
+    - Main docs center `init`/`regen`; preview workflow less prominent.
 - **recommended next prompt or owner**: Covered by `docs/specs/030-discovery-surface-and-docs-alignment/spec.md`.
 
 ## Horizon buckets
 
 ### Quick wins
+
 1. Discovery surface clarity and docs alignment
 2. Command and doc model simplification sweep
 3. Power-user planning workflow visibility
 
 ### Next big bets
+
 1. Versioned private overlay and preset catalogs
 2. Preset-led onboarding for common jobs-to-be-done
 
 ### Longer-term options
+
 - Catalog version upgrade assistant after private catalogs foundation exists
 - Usage analytics or feedback loops to validate preset/discovery effectiveness
 
 ## Notes
+
 - Ranking based on repository evidence only. No telemetry, issue volume, or conversion data reviewed.
 - Quick-win items likely compound together and may be worth bundling into one user-facing discovery/onboarding initiative.

--- a/docs/specs/029-versioned-private-catalogs/spec.md
+++ b/docs/specs/029-versioned-private-catalogs/spec.md
@@ -128,14 +128,14 @@ catalogs:
 Supported v1 source types:
 
 1. `git`
-   - exact commit required for deterministic replay
-   - tag may be retained as advisory metadata
+    - exact commit required for deterministic replay
+    - tag may be retained as advisory metadata
 2. `archive`
-   - pinned HTTPS artifact
-   - checksum required
+    - pinned HTTPS artifact
+    - checksum required
 3. `path`
-   - local or repo-relative authoring/dev source only
-   - treated as non-portable for shared team config unless explicitly repo-relative
+    - local or repo-relative authoring/dev source only
+    - treated as non-portable for shared team config unless explicitly repo-relative
 
 Unsupported in v1:
 
@@ -245,14 +245,14 @@ Origin metadata must be available to diagnostics and explain/list output when re
 
 ### Risks and mitigations
 
-| Risk | Impact | Mitigation |
-|---|---|---|
-| Dynamic registry breaks static schema enums | weaker editor UX or false validation | use two-stage validation; relax static enum where needed; keep runtime errors precise |
-| Silent shadowing between built-in and private IDs | wrong overlay/preset resolved | require namespace-qualified external IDs by default; explicit override only |
-| Non-deterministic remote sources | CI drift | require immutable pins and integrity metadata |
-| Credential leakage into config | security issue | only use ambient auth/environment; reject inline secrets |
-| Different commands resolve different registries | trust break | centralize resolution behind one shared effective-registry pipeline |
-| Stale cache causes confusing behavior | hidden drift | identity-addressed cache plus doctor/diagnostic visibility |
+| Risk                                              | Impact                               | Mitigation                                                                            |
+| ------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------- |
+| Dynamic registry breaks static schema enums       | weaker editor UX or false validation | use two-stage validation; relax static enum where needed; keep runtime errors precise |
+| Silent shadowing between built-in and private IDs | wrong overlay/preset resolved        | require namespace-qualified external IDs by default; explicit override only           |
+| Non-deterministic remote sources                  | CI drift                             | require immutable pins and integrity metadata                                         |
+| Credential leakage into config                    | security issue                       | only use ambient auth/environment; reject inline secrets                              |
+| Different commands resolve different registries   | trust break                          | centralize resolution behind one shared effective-registry pipeline                   |
+| Stale cache causes confusing behavior             | hidden drift                         | identity-addressed cache plus doctor/diagnostic visibility                            |
 
 ### Implementation slices
 
@@ -299,19 +299,19 @@ Even if technically possible, v1 does not require:
 
 ## Acceptance Criteria
 
-| # | Criterion |
-|---|---|
-| AC-1 | Product supports project-level declaration of zero or more additional overlay/preset catalogs in canonical `superposition.yml` without changing behavior for projects that omit `catalogs:`. |
-| AC-2 | Shared remote catalog declarations require immutable pinning; floating refs are rejected. |
-| AC-3 | Supported v1 source types are explicitly limited to `git`, `archive`, and `path`, with unsupported kinds rejected clearly. |
-| AC-4 | Credentials are never stored in project file; authentication relies on environment or host tooling. |
-| AC-5 | External catalog overlays/presets are selectable through existing project-file concepts rather than parallel selection model. |
-| AC-6 | Built-in and external catalog collisions fail closed by default; no silent shadowing occurs. |
-| AC-7 | Every command surface that consumes registry data resolves same effective merged registry for same project file. |
-| AC-8 | Generated receipt/manifest records resolved catalog identities sufficient for audit and troubleshooting. |
-| AC-9 | Validation supports dynamic catalog-backed IDs through two-stage resolution and produces actionable errors when referenced items are missing. |
-| AC-10 | Upgrade workflow based on reviewable pin changes is documented, and failures caused by removed/renamed catalog items are surfaced clearly. |
-| AC-11 | Automated tests cover successful resolution plus failure paths for pinning, integrity, collisions, and cross-command consistency. |
+| #     | Criterion                                                                                                                                                                                    |
+| ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC-1  | Product supports project-level declaration of zero or more additional overlay/preset catalogs in canonical `superposition.yml` without changing behavior for projects that omit `catalogs:`. |
+| AC-2  | Shared remote catalog declarations require immutable pinning; floating refs are rejected.                                                                                                    |
+| AC-3  | Supported v1 source types are explicitly limited to `git`, `archive`, and `path`, with unsupported kinds rejected clearly.                                                                   |
+| AC-4  | Credentials are never stored in project file; authentication relies on environment or host tooling.                                                                                          |
+| AC-5  | External catalog overlays/presets are selectable through existing project-file concepts rather than parallel selection model.                                                                |
+| AC-6  | Built-in and external catalog collisions fail closed by default; no silent shadowing occurs.                                                                                                 |
+| AC-7  | Every command surface that consumes registry data resolves same effective merged registry for same project file.                                                                             |
+| AC-8  | Generated receipt/manifest records resolved catalog identities sufficient for audit and troubleshooting.                                                                                     |
+| AC-9  | Validation supports dynamic catalog-backed IDs through two-stage resolution and produces actionable errors when referenced items are missing.                                                |
+| AC-10 | Upgrade workflow based on reviewable pin changes is documented, and failures caused by removed/renamed catalog items are surfaced clearly.                                                   |
+| AC-11 | Automated tests cover successful resolution plus failure paths for pinning, integrity, collisions, and cross-command consistency.                                                            |
 
 ## Architecture Decision Impact
 

--- a/docs/specs/029-versioned-private-catalogs/spec.md
+++ b/docs/specs/029-versioned-private-catalogs/spec.md
@@ -1,0 +1,326 @@
+# Feature Specification: Versioned Private Overlay and Preset Catalogs
+
+**Spec ID**: `029-versioned-private-catalogs`
+**Taxonomy**: `PROJECT`
+**Created**: 2026-06-15
+**Author**: Workflow Orchestrator
+**Status**: Draft
+**Input**: Opportunity backlog item 2 from `docs/opportunities/README.md` — add versioned private overlay/preset catalogs for platform teams, covering source options, pinning, trust model, precedence, upgrade workflow, and compatibility with current `superposition.yml` / `regen` architecture.
+
+---
+
+## Request Classification
+
+Technical and cross-cutting feature. PM draft now reconciled with architecture pass requirements in this document.
+
+## Problem Statement
+
+Current product ships single built-in overlay/preset registry inside CLI package. Platform teams that want private, opinionated overlays or presets must currently fork tool, patch internal overlays into source tree, or copy generated output per repo.
+
+That blocks:
+
+- central platform ownership of shared stacks
+- independent catalog release cadence
+- reproducible pinning for teams and CI
+- explicit trust and upgrade workflow for organization-specific overlays/presets
+
+Need: project-level way to consume private overlay/preset catalogs as versioned dependencies while preserving deterministic `superposition.yml` → `regen` model.
+
+## User Goals
+
+### Platform team
+
+- Publish internal overlay/preset catalog without forking CLI.
+- Release catalog updates independently.
+- Control which teams can trust and adopt catalog content.
+- Encode org standards in presets and overlays.
+
+### Application team
+
+- Declare catalog dependency in `superposition.yml`.
+- Pin exact catalog version for reproducible local and CI runs.
+- Select private overlays/presets alongside built-ins.
+- Upgrade intentionally through reviewable config changes.
+
+### Maintainer / security owner
+
+- Make trust boundary explicit because catalog content can write files, patch config, and run scripts.
+- Prevent silent override of built-in overlays/presets.
+- Keep credentials out of committed project config.
+
+## Current Behavior and Constraints
+
+### Current behavior
+
+- Overlay registry loads from bundled `overlays/*/overlay.yml` plus bundled presets.
+- `superposition.yml` supports `preset` and `presetChoices`, but no external `catalogs` field.
+- Config validation, schema generation, `list`, `explain`, `doctor`, and composition assume single bundled registry.
+
+### Relevant implementation constraints
+
+1. Validation currently assumes bundled overlay/preset enums.
+2. Schema generation currently emits static enums from bundled registry.
+3. Preset loading assumes bundled filesystem paths.
+4. Overlay loading assumes local filesystem under single overlays root.
+
+Any shipped feature must work consistently across `init`, `regen`, `doctor`, `list`, `explain`, and schema-aware authoring.
+
+## Scope
+
+### In scope
+
+- Project-level declaration of additional catalogs.
+- Supported source types for v1.
+- Pinning and integrity rules.
+- Trust model and credential handling rules.
+- Namespace and collision behavior.
+- Effective merged-registry behavior across commands.
+- Upgrade workflow expectations.
+- Validation/schema behavior for dynamic catalog-backed IDs.
+
+### Out of scope
+
+- Public marketplace/discovery service.
+- Auto-upgrading floating refs.
+- Storing tokens/keys in project file.
+- Replacing bundled catalog.
+- Arbitrary plugin execution beyond existing overlay/preset model.
+- Transitive catalog dependencies in v1.
+
+## Must Preserve
+
+- Projects with no external catalogs behave exactly as today.
+- `superposition.yml` remains canonical committed source of intent.
+- `regen` remains non-interactive and deterministic in CI.
+- Built-in bundled catalog remains available without extra setup.
+
+## Proposed Product Behavior
+
+### 1. `superposition.yml` gains `catalogs:`
+
+Project config gains top-level `catalogs:` array. Each entry declares enough data for deterministic replay:
+
+- stable catalog ID
+- namespace
+- source type
+- source location
+- immutable pin
+- resolved identity / integrity material
+- optional subpath
+- optional explicit override policy
+
+Illustrative shape:
+
+```yaml
+catalogs:
+    - id: acme-platform
+      namespace: acme
+      source:
+          type: git
+          url: ssh://git.example.com/platform/superposition-catalog.git
+          ref: v1.4.2
+          commit: 9f4c2d1
+          subpath: catalog
+```
+
+### 2. Narrow v1 source matrix
+
+Supported v1 source types:
+
+1. `git`
+   - exact commit required for deterministic replay
+   - tag may be retained as advisory metadata
+2. `archive`
+   - pinned HTTPS artifact
+   - checksum required
+3. `path`
+   - local or repo-relative authoring/dev source only
+   - treated as non-portable for shared team config unless explicitly repo-relative
+
+Unsupported in v1:
+
+- OCI artifacts
+- npm package catalogs
+- arbitrary command fetchers
+
+### 3. Pinning and integrity rules
+
+- Shared/committed remote catalogs MUST use immutable identity.
+- Floating refs like `main`, `master`, or `latest` MUST be rejected.
+- `git` catalogs MUST record exact commit SHA.
+- `archive` catalogs MUST record checksum.
+- Resolved catalog identity used for generation MUST be recorded in generated receipt/manifest for audit and doctor diagnostics.
+
+### 4. Trust model
+
+External catalogs are trusted-code input.
+
+Therefore:
+
+- bundled catalog is implicitly trusted
+- external catalogs require explicit declaration in project file
+- credentials come from environment, Git, or host tooling — never project file
+- fetch/auth/integrity failures fail closed
+- tool MUST clearly surface that catalog content can affect generated files and scripts
+
+### 5. Namespace and collision rules
+
+Default behavior: no silent collisions.
+
+- Built-in IDs remain unqualified.
+- External catalogs MUST be addressable through namespace-qualified IDs (example: `acme/web-api`).
+- Unqualified external IDs MUST NOT silently shadow built-ins.
+- Explicit override policy, if supported, must be narrow, reviewable, and deterministic.
+- Same project file must resolve same precedence in every command surface.
+
+### 6. Upgrade workflow
+
+Minimum supported workflow:
+
+1. team edits pinned catalog version in `superposition.yml`
+2. tool resolves new catalog deterministically
+3. `plan`/`regen`/`doctor` surfaces changed catalog identity and invalid references if upgrade removed or renamed items
+4. generated receipt records old/new effective catalog identities for troubleshooting
+
+Manual pin editing is acceptable in v1. Dedicated upgrade helper command is follow-on, not required.
+
+### 7. Dynamic validation behavior
+
+Because full registry is no longer purely bundled/static, validation becomes two-stage:
+
+1. parse and minimally validate raw project config structure, including `catalogs:`
+2. resolve effective registry from bundled + external catalogs
+3. run overlay/preset ID validation against resolved registry
+
+Static schema/editor validation may remain partially relaxed for dynamic IDs so long as runtime validation remains precise and actionable.
+
+## Technical Design Snapshot
+
+### Ownership boundaries
+
+- **Project config loader** owns raw `catalogs:` parsing and structural validation.
+- **Catalog resolver** owns fetch/cache/materialize/verify for external catalogs.
+- **Registry loader** owns merging bundled and external overlays/presets into one effective registry.
+- **Command surfaces** (`init`, `regen`, `doctor`, `list`, `explain`) consume same resolved registry contract rather than bespoke loading paths.
+- **Schema generation/editor support** owns static authoring experience and must degrade safely when dynamic IDs are present.
+
+### Data flow
+
+1. discover repository project file
+2. parse project config including `catalogs:` declarations
+3. structurally validate catalog declarations
+4. resolve and verify each catalog source
+5. materialize catalog contents into local cache/work area
+6. load bundled registry + external registry entries
+7. detect namespace/collision/override violations
+8. validate selected overlays/presets against effective registry
+9. execute existing composition/planning/list/explain flows using same effective registry object
+10. emit receipt metadata including resolved catalog identities
+
+### Interfaces and contracts
+
+#### Project config contract
+
+- Add top-level `catalogs:` field.
+- Catalog entry must include `id`, `namespace`, and `source`.
+- Source-specific required fields enforced after `type` discrimination.
+
+#### Effective registry contract
+
+Resolved registry MUST carry origin metadata per overlay/preset:
+
+- source catalog ID
+- namespace
+- resolved version/identity
+- built-in vs external source kind
+
+Origin metadata must be available to diagnostics and explain/list output when relevant.
+
+#### Cache/materialization contract
+
+- Catalog resolution may use local cache.
+- Cache MUST be content-addressed or identity-addressed by immutable pin.
+- Cache hits MUST not change effective output compared with fresh fetch of same identity.
+- Failed or partial fetch MUST not leave ambiguous mixed-version state.
+
+### Risks and mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| Dynamic registry breaks static schema enums | weaker editor UX or false validation | use two-stage validation; relax static enum where needed; keep runtime errors precise |
+| Silent shadowing between built-in and private IDs | wrong overlay/preset resolved | require namespace-qualified external IDs by default; explicit override only |
+| Non-deterministic remote sources | CI drift | require immutable pins and integrity metadata |
+| Credential leakage into config | security issue | only use ambient auth/environment; reject inline secrets |
+| Different commands resolve different registries | trust break | centralize resolution behind one shared effective-registry pipeline |
+| Stale cache causes confusing behavior | hidden drift | identity-addressed cache plus doctor/diagnostic visibility |
+
+### Implementation slices
+
+1. config/schema slice — raw `catalogs:` parsing and structural validation
+2. resolver slice — fetch/verify/materialize supported source types
+3. registry slice — merge bundled + external catalogs with origin metadata and collision rules
+4. command integration slice — route `init`, `regen`, `doctor`, `list`, `explain`, `plan` through same resolved registry
+5. diagnostics slice — receipt metadata, doctor findings, user-facing error/help text
+6. editor/schema slice — clear authoring story for dynamic IDs
+
+### Test strategy
+
+- unit tests for catalog declaration validation per source type
+- unit tests for pin rejection (`main`, `latest`, missing checksum, missing commit)
+- unit tests for namespace/collision/override rules
+- unit tests for effective-registry merge and origin metadata
+- integration tests for `regen`, `list`, `explain`, `doctor`, and `plan` using sample external catalogs
+- regression tests proving same project file yields same effective registry across commands
+- failure-path tests for auth failure, checksum mismatch, missing overlay ID after upgrade, and stale cache reuse
+
+## Non-Goals Within v1 Slice
+
+Even if technically possible, v1 does not require:
+
+- project-hosted marketplace UI
+- separate lockfile
+- multiple versions of same catalog in one project
+- automatic migration from built-in preset IDs to external ones
+- signed catalogs if immutable pins + integrity checks satisfy org policy
+
+## Success Signals
+
+- Platform team publishes reusable private catalog without forking CLI.
+- Two repos pinned to same catalog identity generate same result in CI.
+- Upgrade happens through reviewable config diff, not cache drift.
+- Collision behavior fails closed.
+- Same project file yields same effective registry in every command surface.
+
+## Open Questions
+
+1. Should repo-shared config allow any non-repo-relative `path` source, or should shared configs reject `path` entirely outside local/dev mode?
+2. Does v1 need explicit built-in allowlist/host allowlist policy in addition to immutable pins and integrity checks?
+3. Should override policy exist in v1 at all, or should v1 require strict namespace-only usage with no shadowing escape hatch?
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|---|
+| AC-1 | Product supports project-level declaration of zero or more additional overlay/preset catalogs in canonical `superposition.yml` without changing behavior for projects that omit `catalogs:`. |
+| AC-2 | Shared remote catalog declarations require immutable pinning; floating refs are rejected. |
+| AC-3 | Supported v1 source types are explicitly limited to `git`, `archive`, and `path`, with unsupported kinds rejected clearly. |
+| AC-4 | Credentials are never stored in project file; authentication relies on environment or host tooling. |
+| AC-5 | External catalog overlays/presets are selectable through existing project-file concepts rather than parallel selection model. |
+| AC-6 | Built-in and external catalog collisions fail closed by default; no silent shadowing occurs. |
+| AC-7 | Every command surface that consumes registry data resolves same effective merged registry for same project file. |
+| AC-8 | Generated receipt/manifest records resolved catalog identities sufficient for audit and troubleshooting. |
+| AC-9 | Validation supports dynamic catalog-backed IDs through two-stage resolution and produces actionable errors when referenced items are missing. |
+| AC-10 | Upgrade workflow based on reviewable pin changes is documented, and failures caused by removed/renamed catalog items are surfaced clearly. |
+| AC-11 | Automated tests cover successful resolution plus failure paths for pinning, integrity, collisions, and cross-command consistency. |
+
+## Architecture Decision Impact
+
+New ADR needed.
+
+Reason: feature changes trust boundary, registry resolution order, validation model, cache/materialization responsibilities, and cross-command ownership model.
+
+## Routing Decision
+
+**PM → Developer**
+
+Reason: product scope, UX constraints, technical ownership, risks, implementation slices, and test strategy now explicit. ADR creation remains required alongside implementation planning, but no further discovery is blocking spec readiness.

--- a/docs/specs/030-discovery-surface-and-docs-alignment/spec.md
+++ b/docs/specs/030-discovery-surface-and-docs-alignment/spec.md
@@ -136,16 +136,16 @@ Migration-only docs may still mention old patterns when clearly marked as legacy
 
 ## Acceptance Criteria
 
-| # | Criterion |
-|---|---|
-| AC-1 | Default discovery output includes all live user-facing overlay categories, including `messaging`, when applicable to current catalog. |
-| AC-2 | Category-filtered discovery tables render port metadata in human-readable form and never display `[object Object]`. |
+| #    | Criterion                                                                                                                                                                                                                                               |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC-1 | Default discovery output includes all live user-facing overlay categories, including `messaging`, when applicable to current catalog.                                                                                                                   |
+| AC-2 | Category-filtered discovery tables render port metadata in human-readable form and never display `[object Object]`.                                                                                                                                     |
 | AC-3 | `README.md`, `tool/README.md`, `docs/quick-reference.md`, `docs/examples.md`, `docs/team-workflow.md`, and `docs/messaging-quick-start.md` teach current canonical workflow rather than deprecated manifest-first or category-centric primary guidance. |
-| AC-4 | Primary examples use `superposition.yml` plus flat `overlays:` as preferred explicit selection model, with any legacy syntax clearly labeled as migration/compatibility-only if retained. |
-| AC-5 | First-run docs surface `plan`, `plan --verbose`, and `plan --diff` as preview-first workflow before file generation or regeneration. |
-| AC-6 | End-user docs do not present stale flags, stale examples, or implementation internals (`_serviceOrder`) as current recommended workflow. |
-| AC-7 | Changes preserve current command semantics for `init`, `regen`, and `plan`; this spec only changes discovery rendering and user guidance, not planning/generation behavior. |
-| AC-8 | Automated coverage exists for any CLI rendering bug fixed under this spec, including category presence and human-readable field rendering. |
+| AC-4 | Primary examples use `superposition.yml` plus flat `overlays:` as preferred explicit selection model, with any legacy syntax clearly labeled as migration/compatibility-only if retained.                                                               |
+| AC-5 | First-run docs surface `plan`, `plan --verbose`, and `plan --diff` as preview-first workflow before file generation or regeneration.                                                                                                                    |
+| AC-6 | End-user docs do not present stale flags, stale examples, or implementation internals (`_serviceOrder`) as current recommended workflow.                                                                                                                |
+| AC-7 | Changes preserve current command semantics for `init`, `regen`, and `plan`; this spec only changes discovery rendering and user guidance, not planning/generation behavior.                                                                             |
+| AC-8 | Automated coverage exists for any CLI rendering bug fixed under this spec, including category presence and human-readable field rendering.                                                                                                              |
 
 ## ADR Impact
 

--- a/docs/specs/030-discovery-surface-and-docs-alignment/spec.md
+++ b/docs/specs/030-discovery-surface-and-docs-alignment/spec.md
@@ -1,0 +1,164 @@
+# Feature Specification: Discovery Surface and Canonical Docs Alignment
+
+**Spec ID**: `030-discovery-surface-and-docs-alignment`
+**Taxonomy**: `CLI-UX, DOCS-GUIDE`
+**Created**: 2026-06-22
+**Author**: Workflow Orchestrator
+**Status**: Draft
+**Input**: Opportunity backlog items 1, 3, and 5 from `docs/opportunities/README.md` — fix discovery surface gaps, align docs/help/examples to one canonical model, and make preview-first planning workflow easy to find.
+
+---
+
+## Request Classification
+
+Existing behavior and repo evidence clear enough for direct spec authoring. No blocker user questions found.
+
+This spec intentionally bundles three related backlog items because they share same user problem: users cannot reliably discover current overlays and safest current workflow from first-party surfaces.
+
+- Opportunity 1: Discovery surface clarity and docs alignment
+- Opportunity 3: Command and doc model simplification sweep
+- Opportunity 5: Power-user planning workflow visibility
+
+## Problem Statement
+
+Current product surfaces disagree with current product model.
+
+Observed repo evidence:
+
+- `docs/opportunities/README.md` records that default `list` output omits `messaging` category despite live messaging overlays.
+- Same opportunity notes filtered `list --category ...` tables can render port values as `[object Object]`.
+- `README.md`, `tool/README.md`, `docs/quick-reference.md`, `docs/examples.md`, `docs/team-workflow.md`, and `docs/messaging-quick-start.md` still teach deprecated category-centric config, stale CLI flags, or manifest-first workflows.
+- `plan`, `--verbose`, and `plan --diff` exist but are not consistently presented as safe preview path before writing files.
+
+Result: first-run users learn wrong config shape, power users miss safer preview tools, and discovery trust drops because catalog/docs/help disagree.
+
+## User Goals
+
+### First-time user
+
+- Find current overlays through `list` output without missing live categories.
+- Copy examples that match current canonical `superposition.yml` model.
+- Understand safe path: preview first, then generate.
+
+### Returning user / team maintainer
+
+- See one consistent mental model across README, docs, examples, and command help.
+- Use `superposition.yml` with flat `overlays:` as default authoring pattern.
+- Avoid deprecated flags/examples that create cleanup or migration work.
+
+### Power user
+
+- Discover `plan`, `plan --verbose`, and `plan --diff` quickly.
+- Compare intended changes before `init`/`regen` writes output.
+
+## Scope
+
+### In scope
+
+- Fix discovery output gaps in `list` for current overlay categories and port rendering.
+- Rewrite first-party docs/help/examples to teach one canonical config model.
+- Promote preview-first workflow in top-level docs and quick-reference surfaces.
+- Align messaging examples with current command and config model.
+- Define deprecation cleanup for stale examples and stale terminology.
+
+### Out of scope
+
+- Adding new overlays, presets, or categories.
+- Redesigning preset system itself.
+- New planning engine behavior beyond discoverability and wording.
+- External/private catalog support.
+
+## Must Preserve
+
+- `superposition.yml` remains canonical generation input.
+- Advanced users can still specify overlays directly without presets.
+- Existing `plan`, `plan --verbose`, and `plan --diff` semantics remain unchanged unless another spec changes them.
+
+## Proposed Behavior
+
+### 1. Discovery surfaces reflect live catalog
+
+Default overlay discovery output MUST include every live top-level category intended for user selection, including `messaging`.
+
+Category-filtered tabular output MUST render ports and similar structured fields as human-readable values, never raw object stringification like `[object Object]`.
+
+### 2. Canonical docs model becomes flat `overlays:` + project-file-first
+
+Primary docs and examples MUST teach:
+
+- project-file-first workflow
+- `superposition.yml` / `.superposition.yml` canonical input
+- flat `overlays:` selection as default explicit authoring model
+- `preset` as optional shortcut, not alternate configuration architecture
+
+Docs MUST stop teaching deprecated category-centric top-level fields like `language:` / `database:` as primary model except where explicitly documented for backward compatibility or migration context.
+
+### 3. Preview-first workflow becomes explicit
+
+Top-level onboarding docs MUST present preview path before generation:
+
+1. discover overlays/presets
+2. preview with `plan`
+3. inspect reasons with `--verbose`
+4. inspect diff when changing existing config with `plan --diff`
+5. run `init` or `regen`
+
+### 4. Stale command examples removed or reframed
+
+Docs/help/examples MUST stop presenting stale patterns as current guidance, including:
+
+- `--postgres` style examples when canonical examples should use current overlay/config forms
+- `cs list --presets` when current discovery path differs
+- `_serviceOrder` references in end-user docs
+- manifest-first team workflow examples that center `superposition.json` instead of project file
+
+Migration-only docs may still mention old patterns when clearly marked as legacy or transition-only.
+
+## UX Contract
+
+### Information hierarchy
+
+- README quickstart leads with `init`, canonical `superposition.yml`, `plan`, `regen`.
+- Quick reference and examples mirror same order.
+- Messaging guide uses same command vocabulary and config model as README.
+
+### Copy contract
+
+- Say `superposition.yml` is canonical input.
+- Say flat `overlays:` is preferred explicit selection model.
+- Present presets as guided shortcut for common jobs, not hidden expert feature.
+- Present `plan` as preview, `plan --verbose` as explanation, `plan --diff` as change review.
+
+### Error/edge presentation
+
+- Discovery output never exposes implementation formatting artifacts like `[object Object]`.
+- If category filtering omits results, wording must make absence explicit rather than silently hiding live category families.
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|---|
+| AC-1 | Default discovery output includes all live user-facing overlay categories, including `messaging`, when applicable to current catalog. |
+| AC-2 | Category-filtered discovery tables render port metadata in human-readable form and never display `[object Object]`. |
+| AC-3 | `README.md`, `tool/README.md`, `docs/quick-reference.md`, `docs/examples.md`, `docs/team-workflow.md`, and `docs/messaging-quick-start.md` teach current canonical workflow rather than deprecated manifest-first or category-centric primary guidance. |
+| AC-4 | Primary examples use `superposition.yml` plus flat `overlays:` as preferred explicit selection model, with any legacy syntax clearly labeled as migration/compatibility-only if retained. |
+| AC-5 | First-run docs surface `plan`, `plan --verbose`, and `plan --diff` as preview-first workflow before file generation or regeneration. |
+| AC-6 | End-user docs do not present stale flags, stale examples, or implementation internals (`_serviceOrder`) as current recommended workflow. |
+| AC-7 | Changes preserve current command semantics for `init`, `regen`, and `plan`; this spec only changes discovery rendering and user guidance, not planning/generation behavior. |
+| AC-8 | Automated coverage exists for any CLI rendering bug fixed under this spec, including category presence and human-readable field rendering. |
+
+## ADR Impact
+
+Aligned.
+
+No new architecture decision required. Work stays within existing project-file-first product direction.
+
+## Open Questions
+
+None blocking spec completion.
+
+## Routing Decision
+
+**PM → Developer**
+
+Reason: UX contract and scope boundaries now explicit; no further architecture pass required.

--- a/docs/specs/031-preset-led-onboarding-for-common-jobs/spec.md
+++ b/docs/specs/031-preset-led-onboarding-for-common-jobs/spec.md
@@ -1,0 +1,158 @@
+# Feature Specification: Preset-Led Onboarding for Common Jobs-to-be-Done
+
+**Spec ID**: `031-preset-led-onboarding-for-common-jobs`
+**Taxonomy**: `CLI-UX, DOCS-GUIDE`
+**Created**: 2026-06-22
+**Author**: Workflow Orchestrator
+**Status**: Draft
+**Input**: Opportunity backlog item 4 from `docs/opportunities/README.md` — steer first-run users toward opinionated presets for common jobs-to-be-done instead of forcing large-catalog selection first.
+
+---
+
+## Request Classification
+
+User-facing onboarding problem. Existing repo evidence sufficient for PM+UX finalization without blocker discovery round.
+
+## Problem Statement
+
+Current product has enough overlays and options to create choice overload for first-run users.
+
+Observed repo evidence:
+
+- Opportunity backlog records 94 catalog items and 13 existing presets.
+- `docs/presets.md` documents strong preset value, but README and some entry surfaces still emphasize manual composability first.
+- Opportunity notes preset-first guidance appears secondary in some entrypoints.
+
+Result: users face catalog breadth before job-oriented starting points, increasing onboarding friction and failed self-service setup.
+
+## User Goals
+
+### First-time user
+
+- Start from common goal like web API, microservice, docs site, or full-stack app.
+- Get sane defaults without understanding full overlay catalog first.
+- Still retain option to customize after preset selection.
+
+### Experienced user
+
+- Keep direct overlay selection available.
+- Understand when preset path is fastest and when manual overlay path is better.
+
+### Team maintainer / docs author
+
+- Recommend consistent onboarding path across README, examples, and preset docs.
+- Reduce cognitive load without hiding composability power.
+
+## Scope
+
+### In scope
+
+- Make preset-first onboarding explicit in first-run docs and interactive guidance where current product already supports it.
+- Define jobs-to-be-done framing for preset entrypoints.
+- Clarify customization path after selecting preset.
+- Define fallback path for users whose need does not fit preset.
+
+### Out of scope
+
+- Creating brand-new preset execution engine.
+- Removing direct overlay selection.
+- Private/versioned preset catalogs.
+- Guaranteeing every possible stack has preset coverage in this slice.
+
+## Must Preserve
+
+- Direct overlay-driven workflow remains supported.
+- Presets remain optional shortcut, not mandatory abstraction.
+- Users can still add/remove overlays after preset expansion when current product supports it.
+
+## Proposed Behavior
+
+### 1. Presets become recommended first-run path for common jobs
+
+First-run surfaces SHOULD recommend presets first for users whose need matches common jobs:
+
+- web API
+- microservice
+- documentation site
+- full-stack application
+- other currently supported preset scenarios documented by product
+
+### 2. Manual overlay path remains visible as advanced/flexible path
+
+Docs and interactive copy MUST make clear that users can:
+
+- start from preset for speed
+- or start from direct overlay selection for bespoke stacks
+
+Neither path should imply other path is deprecated.
+
+### 3. Preset flow explains customization handoff
+
+When preset is recommended, docs and onboarding copy MUST also explain that user can customize after preset selection by:
+
+- choosing preset options (`presetChoices`) where applicable
+- adding overlays not included in preset
+- removing non-required overlays when supported by current flow
+
+### 4. Job-based docs/examples point to preset equivalents
+
+Docs/examples for common stacks SHOULD show:
+
+- preset-first path
+- equivalent explicit overlay path when useful for transparency or automation
+
+This keeps onboarding approachable without hiding resulting stack composition.
+
+## UX Contract
+
+### Entry decision
+
+User should quickly answer: “Does one of these common outcomes match my project?”
+
+If yes:
+- choose preset path
+
+If no:
+- choose direct overlay path
+
+### Copy contract
+
+- Present presets as fastest way to get started.
+- Present overlays as flexible composition layer.
+- Avoid language implying presets are toy mode or overlays are only expert path.
+- Use job-focused labels before implementation-focused labels when introducing preset choices.
+
+### State/navigation contract
+
+- First-run docs link from generic getting-started surfaces to preset guide.
+- Preset guide links back to explicit overlay/config equivalents.
+- Customization step appears after preset recommendation, not hidden in later deep docs.
+
+## Acceptance Criteria
+
+| # | Criterion |
+|---|---|
+| AC-1 | First-run documentation recommends presets as default starting path for common jobs-to-be-done while preserving direct overlay selection as supported alternative. |
+| AC-2 | README and related getting-started surfaces point users to preset-oriented entry guidance when their use case matches a common preset. |
+| AC-3 | `docs/presets.md` and linked onboarding surfaces explain how users customize after selecting a preset, including `presetChoices` and overlay-level additions/removals where supported. |
+| AC-4 | At least core common scenarios documented by current product have job-oriented preset guidance and, where useful, equivalent explicit overlay/config examples for transparency. |
+| AC-5 | Guidance clearly tells users what to do when no preset fits: use flat `overlays:` or direct interactive overlay selection. |
+| AC-6 | This spec does not remove or hide advanced composability; it changes recommendation order and explanatory copy only. |
+| AC-7 | If interactive questionnaire copy or menu ordering changes under this spec, tests or snapshots cover new recommendation wording/order. |
+
+## ADR Impact
+
+Aligned.
+
+No new ADR required. Product behavior stays within current preset architecture.
+
+## Assumptions
+
+1. Existing preset catalog is sufficient for first ship of preset-led onboarding improvements.
+2. Work may adjust docs and current questionnaire wording/order, but not preset expansion semantics.
+
+## Routing Decision
+
+**PM → Developer**
+
+Reason: UX contract, scope, and preservation rules explicit. No further architecture discovery required.

--- a/docs/specs/031-preset-led-onboarding-for-common-jobs/spec.md
+++ b/docs/specs/031-preset-led-onboarding-for-common-jobs/spec.md
@@ -110,9 +110,11 @@ This keeps onboarding approachable without hiding resulting stack composition.
 User should quickly answer: “Does one of these common outcomes match my project?”
 
 If yes:
+
 - choose preset path
 
 If no:
+
 - choose direct overlay path
 
 ### Copy contract
@@ -130,15 +132,15 @@ If no:
 
 ## Acceptance Criteria
 
-| # | Criterion |
-|---|---|
-| AC-1 | First-run documentation recommends presets as default starting path for common jobs-to-be-done while preserving direct overlay selection as supported alternative. |
-| AC-2 | README and related getting-started surfaces point users to preset-oriented entry guidance when their use case matches a common preset. |
+| #    | Criterion                                                                                                                                                                              |
+| ---- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AC-1 | First-run documentation recommends presets as default starting path for common jobs-to-be-done while preserving direct overlay selection as supported alternative.                     |
+| AC-2 | README and related getting-started surfaces point users to preset-oriented entry guidance when their use case matches a common preset.                                                 |
 | AC-3 | `docs/presets.md` and linked onboarding surfaces explain how users customize after selecting a preset, including `presetChoices` and overlay-level additions/removals where supported. |
-| AC-4 | At least core common scenarios documented by current product have job-oriented preset guidance and, where useful, equivalent explicit overlay/config examples for transparency. |
-| AC-5 | Guidance clearly tells users what to do when no preset fits: use flat `overlays:` or direct interactive overlay selection. |
-| AC-6 | This spec does not remove or hide advanced composability; it changes recommendation order and explanatory copy only. |
-| AC-7 | If interactive questionnaire copy or menu ordering changes under this spec, tests or snapshots cover new recommendation wording/order. |
+| AC-4 | At least core common scenarios documented by current product have job-oriented preset guidance and, where useful, equivalent explicit overlay/config examples for transparency.        |
+| AC-5 | Guidance clearly tells users what to do when no preset fits: use flat `overlays:` or direct interactive overlay selection.                                                             |
+| AC-6 | This spec does not remove or hide advanced composability; it changes recommendation order and explanatory copy only.                                                                   |
+| AC-7 | If interactive questionnaire copy or menu ordering changes under this spec, tests or snapshots cover new recommendation wording/order.                                                 |
 
 ## ADR Impact
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,35 +1,35 @@
 # Specs Index
 
-| Spec                                                                                         | Title                                                             | Status      | Taxonomy             |
-| -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ----------- | -------------------- |
-| [001-verbose-plan-graph](001-verbose-plan-graph/spec.md)                                     | Verbose Plan Graph                                                | Final       | CLI-UX               |
-| [002-superposition-config-file](002-superposition-config-file/spec.md)                       | Project Configuration File                                        | Final       | PROJECT              |
-| [003-mkdocs2-overlay](003-mkdocs2-overlay/spec.md)                                           | MkDocs 2.x Overlay                                                | Final       | OVERLAY-NEW          |
-| [004-doctor-fix](004-doctor-fix/spec.md)                                                     | `doctor --fix` — Interactive Auto-Repair                          | Final       | CLI-COMMAND          |
-| [005-cuda-overlay](005-cuda-overlay/spec.md)                                                 | CUDA (NVIDIA GPU) Overlay                                         | Final       | OVERLAY-NEW          |
-| [006-rocm-overlay](006-rocm-overlay/spec.md)                                                 | ROCm (AMD GPU) Overlay                                            | Final       | OVERLAY-NEW          |
-| [007-target-aware-generation](007-target-aware-generation/spec.md)                           | Target-Aware Generation                                           | Final       | CLI-FLAG             |
-| [008-project-file-canonical](008-project-file-canonical/spec.md)                             | Make superposition.yml Canonical Input                            | Approved    | PROJECT              |
-| [009-project-env](009-project-env/spec.md)                                                   | Unified Project-Level Environment Variables                       | Approved    | PROJECT              |
-| [010-compose-env-materialization](010-compose-env-materialization/spec.md)                   | Compose Env Materialization and Env Template Naming               | Approved    | COMPOSER-FEAT        |
-| [011-overlay-parameters](011-overlay-parameters/spec.md)                                     | Overlay Parameters with Safe Substitution                         | Final       | SCHEMA-FIELD         |
-| [012-ollama-cli-overlay](012-ollama-cli-overlay/spec.md)                                     | Split Ollama Service and CLI Overlays                             | Final       | OVERLAY-NEW          |
-| [013-doctor-dependency-check](013-doctor-dependency-check/spec.md)                           | Doctor Overlay Dependency Resolution Check                        | Approved    | CLI-UX               |
-| [014-doctor-compose-port-cross-validation](014-doctor-compose-port-cross-validation/spec.md) | Doctor Compose / Port Cross-Validation                            | Approved    | CLI-UX               |
-| [015-doctor-env-example-drift](015-doctor-env-example-drift/spec.md)                         | Doctor `.env.example` Drift Detection                             | Approved    | CLI-UX               |
-| [016-doctor-reproducibility-check](016-doctor-reproducibility-check/spec.md)                 | Doctor Reproducibility Check                                      | Approved    | CLI-UX               |
-| [017-doctor-dry-run](017-doctor-dry-run/spec.md)                                             | Doctor `--fix --dry-run` Flag                                     | Approved    | CLI-FLAG             |
-| [018-init-project-file](018-init-project-file/spec.md)                                       | `init --project-file`                                             | Final       | PROJECT              |
-| [019-project-mounts](019-project-mounts/spec.md)                                             | First-Class Mounts Support                                        | Approved    | PROJECT              |
-| [020-superposition-yml-schema](020-superposition-yml-schema/spec.md)                         | JSON Schema for `superposition.yml`                               | Approved    | SCHEMA-FIELD         |
-| [021-deterministic-generated-readme](021-deterministic-generated-readme/spec.md)             | Deterministic Generated README Header                             | Approved    | CLI-UX               |
-| [022-local-superposition-config](022-local-superposition-config/spec.md)                     | Local Superposition Config                                        | Final       | PROJECT              |
-| [023-pr-prerelease-gate](023-pr-prerelease-gate/spec.md)                                     | PR Prerelease Deployment Gate                                     | Final       | INFRA-BUILD          |
-| [024-project-ports](024-project-ports/spec.md)                                               | Project-Level `ports` Field (plain/compose redesign)              | Final       | SCHEMA-FIELD         |
-| [025-variable-expansion-consolidation](025-variable-expansion-consolidation/spec.md)         | Variable Expansion and Substitution Consolidation                 | Final       | SCHEMA-FIELD, CLI-UX |
-| [026-adhoc-project-parameters](026-adhoc-project-parameters/spec.md)                         | Ad-hoc Project Parameters                                         | Final       | SCHEMA-FIELD, CLI-UX |
-| [027-devcontainer-gitignore-content](027-devcontainer-gitignore-content/spec.md)             | devcontainerGitignore — Drop `!.gitignore` from Generated Content | Final       | CLI-UX               |
-| [028-publish-summaries-and-pr-comments](028-publish-summaries-and-pr-comments/spec.md)       | Publish Workflow Summaries and PR Comment Parity                  | Implemented | INFRA-BUILD          |
-| [029-versioned-private-catalogs](029-versioned-private-catalogs/spec.md)                     | Versioned Private Overlay and Preset Catalogs                     | Draft       | PROJECT              |
-| [030-discovery-surface-and-docs-alignment](030-discovery-surface-and-docs-alignment/spec.md) | Discovery Surface and Canonical Docs Alignment                    | Draft       | CLI-UX, DOCS-GUIDE   |
-| [031-preset-led-onboarding-for-common-jobs](031-preset-led-onboarding-for-common-jobs/spec.md) | Preset-Led Onboarding for Common Jobs-to-be-Done                | Draft       | CLI-UX, DOCS-GUIDE   |
+| Spec                                                                                           | Title                                                             | Status      | Taxonomy             |
+| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- | ----------- | -------------------- |
+| [001-verbose-plan-graph](001-verbose-plan-graph/spec.md)                                       | Verbose Plan Graph                                                | Final       | CLI-UX               |
+| [002-superposition-config-file](002-superposition-config-file/spec.md)                         | Project Configuration File                                        | Final       | PROJECT              |
+| [003-mkdocs2-overlay](003-mkdocs2-overlay/spec.md)                                             | MkDocs 2.x Overlay                                                | Final       | OVERLAY-NEW          |
+| [004-doctor-fix](004-doctor-fix/spec.md)                                                       | `doctor --fix` — Interactive Auto-Repair                          | Final       | CLI-COMMAND          |
+| [005-cuda-overlay](005-cuda-overlay/spec.md)                                                   | CUDA (NVIDIA GPU) Overlay                                         | Final       | OVERLAY-NEW          |
+| [006-rocm-overlay](006-rocm-overlay/spec.md)                                                   | ROCm (AMD GPU) Overlay                                            | Final       | OVERLAY-NEW          |
+| [007-target-aware-generation](007-target-aware-generation/spec.md)                             | Target-Aware Generation                                           | Final       | CLI-FLAG             |
+| [008-project-file-canonical](008-project-file-canonical/spec.md)                               | Make superposition.yml Canonical Input                            | Approved    | PROJECT              |
+| [009-project-env](009-project-env/spec.md)                                                     | Unified Project-Level Environment Variables                       | Approved    | PROJECT              |
+| [010-compose-env-materialization](010-compose-env-materialization/spec.md)                     | Compose Env Materialization and Env Template Naming               | Approved    | COMPOSER-FEAT        |
+| [011-overlay-parameters](011-overlay-parameters/spec.md)                                       | Overlay Parameters with Safe Substitution                         | Final       | SCHEMA-FIELD         |
+| [012-ollama-cli-overlay](012-ollama-cli-overlay/spec.md)                                       | Split Ollama Service and CLI Overlays                             | Final       | OVERLAY-NEW          |
+| [013-doctor-dependency-check](013-doctor-dependency-check/spec.md)                             | Doctor Overlay Dependency Resolution Check                        | Approved    | CLI-UX               |
+| [014-doctor-compose-port-cross-validation](014-doctor-compose-port-cross-validation/spec.md)   | Doctor Compose / Port Cross-Validation                            | Approved    | CLI-UX               |
+| [015-doctor-env-example-drift](015-doctor-env-example-drift/spec.md)                           | Doctor `.env.example` Drift Detection                             | Approved    | CLI-UX               |
+| [016-doctor-reproducibility-check](016-doctor-reproducibility-check/spec.md)                   | Doctor Reproducibility Check                                      | Approved    | CLI-UX               |
+| [017-doctor-dry-run](017-doctor-dry-run/spec.md)                                               | Doctor `--fix --dry-run` Flag                                     | Approved    | CLI-FLAG             |
+| [018-init-project-file](018-init-project-file/spec.md)                                         | `init --project-file`                                             | Final       | PROJECT              |
+| [019-project-mounts](019-project-mounts/spec.md)                                               | First-Class Mounts Support                                        | Approved    | PROJECT              |
+| [020-superposition-yml-schema](020-superposition-yml-schema/spec.md)                           | JSON Schema for `superposition.yml`                               | Approved    | SCHEMA-FIELD         |
+| [021-deterministic-generated-readme](021-deterministic-generated-readme/spec.md)               | Deterministic Generated README Header                             | Approved    | CLI-UX               |
+| [022-local-superposition-config](022-local-superposition-config/spec.md)                       | Local Superposition Config                                        | Final       | PROJECT              |
+| [023-pr-prerelease-gate](023-pr-prerelease-gate/spec.md)                                       | PR Prerelease Deployment Gate                                     | Final       | INFRA-BUILD          |
+| [024-project-ports](024-project-ports/spec.md)                                                 | Project-Level `ports` Field (plain/compose redesign)              | Final       | SCHEMA-FIELD         |
+| [025-variable-expansion-consolidation](025-variable-expansion-consolidation/spec.md)           | Variable Expansion and Substitution Consolidation                 | Final       | SCHEMA-FIELD, CLI-UX |
+| [026-adhoc-project-parameters](026-adhoc-project-parameters/spec.md)                           | Ad-hoc Project Parameters                                         | Final       | SCHEMA-FIELD, CLI-UX |
+| [027-devcontainer-gitignore-content](027-devcontainer-gitignore-content/spec.md)               | devcontainerGitignore — Drop `!.gitignore` from Generated Content | Final       | CLI-UX               |
+| [028-publish-summaries-and-pr-comments](028-publish-summaries-and-pr-comments/spec.md)         | Publish Workflow Summaries and PR Comment Parity                  | Implemented | INFRA-BUILD          |
+| [029-versioned-private-catalogs](029-versioned-private-catalogs/spec.md)                       | Versioned Private Overlay and Preset Catalogs                     | Draft       | PROJECT              |
+| [030-discovery-surface-and-docs-alignment](030-discovery-surface-and-docs-alignment/spec.md)   | Discovery Surface and Canonical Docs Alignment                    | Draft       | CLI-UX, DOCS-GUIDE   |
+| [031-preset-led-onboarding-for-common-jobs](031-preset-led-onboarding-for-common-jobs/spec.md) | Preset-Led Onboarding for Common Jobs-to-be-Done                  | Draft       | CLI-UX, DOCS-GUIDE   |

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -30,3 +30,6 @@
 | [026-adhoc-project-parameters](026-adhoc-project-parameters/spec.md)                         | Ad-hoc Project Parameters                                         | Final       | SCHEMA-FIELD, CLI-UX |
 | [027-devcontainer-gitignore-content](027-devcontainer-gitignore-content/spec.md)             | devcontainerGitignore — Drop `!.gitignore` from Generated Content | Final       | CLI-UX               |
 | [028-publish-summaries-and-pr-comments](028-publish-summaries-and-pr-comments/spec.md)       | Publish Workflow Summaries and PR Comment Parity                  | Implemented | INFRA-BUILD          |
+| [029-versioned-private-catalogs](029-versioned-private-catalogs/spec.md)                     | Versioned Private Overlay and Preset Catalogs                     | Draft       | PROJECT              |
+| [030-discovery-surface-and-docs-alignment](030-discovery-surface-and-docs-alignment/spec.md) | Discovery Surface and Canonical Docs Alignment                    | Draft       | CLI-UX, DOCS-GUIDE   |
+| [031-preset-led-onboarding-for-common-jobs](031-preset-led-onboarding-for-common-jobs/spec.md) | Preset-Led Onboarding for Common Jobs-to-be-Done                | Draft       | CLI-UX, DOCS-GUIDE   |

--- a/docs/specs/taxonomy.md
+++ b/docs/specs/taxonomy.md
@@ -129,6 +129,8 @@ _No specs yet._
 | [014-doctor-compose-port-cross-validation](014-doctor-compose-port-cross-validation/spec.md) | Doctor Compose / Port Cross-Validation     | Draft  |
 | [015-doctor-env-example-drift](015-doctor-env-example-drift/spec.md)                         | Doctor `.env.example` Drift Detection      | Draft  |
 | [016-doctor-reproducibility-check](016-doctor-reproducibility-check/spec.md)                 | Doctor Reproducibility Check               | Draft  |
+| [030-discovery-surface-and-docs-alignment](030-discovery-surface-and-docs-alignment/spec.md) | Discovery Surface and Canonical Docs Alignment | Draft |
+| [031-preset-led-onboarding-for-common-jobs](031-preset-led-onboarding-for-common-jobs/spec.md) | Preset-Led Onboarding for Common Jobs-to-be-Done | Draft |
 
 ---
 
@@ -152,7 +154,10 @@ _No specs yet._
 
 ### DOCS-GUIDE
 
-_No specs yet._
+| Spec | Title | Status |
+| ---- | ----- | ------ |
+| [030-discovery-surface-and-docs-alignment](030-discovery-surface-and-docs-alignment/spec.md) | Discovery Surface and Canonical Docs Alignment | Draft |
+| [031-preset-led-onboarding-for-common-jobs](031-preset-led-onboarding-for-common-jobs/spec.md) | Preset-Led Onboarding for Common Jobs-to-be-Done | Draft |
 
 ### DOCS-API
 
@@ -188,3 +193,4 @@ _No specs yet._
 | [018-init-project-file](018-init-project-file/spec.md)                   | `init --project-file`                       | Final       |
 | [019-project-mounts](019-project-mounts/spec.md)                         | First-Class Mounts Support                  | Approved    |
 | [022-local-superposition-config](022-local-superposition-config/spec.md) | Local Superposition Config                  | Implemented |
+| [029-versioned-private-catalogs](029-versioned-private-catalogs/spec.md) | Versioned Private Overlay and Preset Catalogs | Draft |

--- a/docs/specs/taxonomy.md
+++ b/docs/specs/taxonomy.md
@@ -122,15 +122,15 @@ _No specs yet._
 
 ### CLI-UX
 
-| Spec                                                                                         | Title                                      | Status |
-| -------------------------------------------------------------------------------------------- | ------------------------------------------ | ------ |
-| [001-verbose-plan-graph](001-verbose-plan-graph/spec.md)                                     | Verbose Plan Graph                         | Final  |
-| [013-doctor-dependency-check](013-doctor-dependency-check/spec.md)                           | Doctor Overlay Dependency Resolution Check | Draft  |
-| [014-doctor-compose-port-cross-validation](014-doctor-compose-port-cross-validation/spec.md) | Doctor Compose / Port Cross-Validation     | Draft  |
-| [015-doctor-env-example-drift](015-doctor-env-example-drift/spec.md)                         | Doctor `.env.example` Drift Detection      | Draft  |
-| [016-doctor-reproducibility-check](016-doctor-reproducibility-check/spec.md)                 | Doctor Reproducibility Check               | Draft  |
-| [030-discovery-surface-and-docs-alignment](030-discovery-surface-and-docs-alignment/spec.md) | Discovery Surface and Canonical Docs Alignment | Draft |
-| [031-preset-led-onboarding-for-common-jobs](031-preset-led-onboarding-for-common-jobs/spec.md) | Preset-Led Onboarding for Common Jobs-to-be-Done | Draft |
+| Spec                                                                                           | Title                                            | Status |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------ |
+| [001-verbose-plan-graph](001-verbose-plan-graph/spec.md)                                       | Verbose Plan Graph                               | Final  |
+| [013-doctor-dependency-check](013-doctor-dependency-check/spec.md)                             | Doctor Overlay Dependency Resolution Check       | Draft  |
+| [014-doctor-compose-port-cross-validation](014-doctor-compose-port-cross-validation/spec.md)   | Doctor Compose / Port Cross-Validation           | Draft  |
+| [015-doctor-env-example-drift](015-doctor-env-example-drift/spec.md)                           | Doctor `.env.example` Drift Detection            | Draft  |
+| [016-doctor-reproducibility-check](016-doctor-reproducibility-check/spec.md)                   | Doctor Reproducibility Check                     | Draft  |
+| [030-discovery-surface-and-docs-alignment](030-discovery-surface-and-docs-alignment/spec.md)   | Discovery Surface and Canonical Docs Alignment   | Draft  |
+| [031-preset-led-onboarding-for-common-jobs](031-preset-led-onboarding-for-common-jobs/spec.md) | Preset-Led Onboarding for Common Jobs-to-be-Done | Draft  |
 
 ---
 
@@ -154,10 +154,10 @@ _No specs yet._
 
 ### DOCS-GUIDE
 
-| Spec | Title | Status |
-| ---- | ----- | ------ |
-| [030-discovery-surface-and-docs-alignment](030-discovery-surface-and-docs-alignment/spec.md) | Discovery Surface and Canonical Docs Alignment | Draft |
-| [031-preset-led-onboarding-for-common-jobs](031-preset-led-onboarding-for-common-jobs/spec.md) | Preset-Led Onboarding for Common Jobs-to-be-Done | Draft |
+| Spec                                                                                           | Title                                            | Status |
+| ---------------------------------------------------------------------------------------------- | ------------------------------------------------ | ------ |
+| [030-discovery-surface-and-docs-alignment](030-discovery-surface-and-docs-alignment/spec.md)   | Discovery Surface and Canonical Docs Alignment   | Draft  |
+| [031-preset-led-onboarding-for-common-jobs](031-preset-led-onboarding-for-common-jobs/spec.md) | Preset-Led Onboarding for Common Jobs-to-be-Done | Draft  |
 
 ### DOCS-API
 
@@ -185,12 +185,12 @@ _No specs yet._
 
 ## PROJECT — Project-level configuration
 
-| Spec                                                                     | Title                                       | Status      |
-| ------------------------------------------------------------------------ | ------------------------------------------- | ----------- |
-| [002-superposition-config-file](002-superposition-config-file/spec.md)   | Project Configuration File                  | Final       |
-| [008-project-file-canonical](008-project-file-canonical/spec.md)         | Project File Canonical Form                 | Approved    |
-| [009-project-env](009-project-env/spec.md)                               | Unified Project-Level Environment Variables | Approved    |
-| [018-init-project-file](018-init-project-file/spec.md)                   | `init --project-file`                       | Final       |
-| [019-project-mounts](019-project-mounts/spec.md)                         | First-Class Mounts Support                  | Approved    |
-| [022-local-superposition-config](022-local-superposition-config/spec.md) | Local Superposition Config                  | Implemented |
-| [029-versioned-private-catalogs](029-versioned-private-catalogs/spec.md) | Versioned Private Overlay and Preset Catalogs | Draft |
+| Spec                                                                     | Title                                         | Status      |
+| ------------------------------------------------------------------------ | --------------------------------------------- | ----------- |
+| [002-superposition-config-file](002-superposition-config-file/spec.md)   | Project Configuration File                    | Final       |
+| [008-project-file-canonical](008-project-file-canonical/spec.md)         | Project File Canonical Form                   | Approved    |
+| [009-project-env](009-project-env/spec.md)                               | Unified Project-Level Environment Variables   | Approved    |
+| [018-init-project-file](018-init-project-file/spec.md)                   | `init --project-file`                         | Final       |
+| [019-project-mounts](019-project-mounts/spec.md)                         | First-Class Mounts Support                    | Approved    |
+| [022-local-superposition-config](022-local-superposition-config/spec.md) | Local Superposition Config                    | Implemented |
+| [029-versioned-private-catalogs](029-versioned-private-catalogs/spec.md) | Versioned Private Overlay and Preset Catalogs | Draft       |

--- a/overlays/git-helpers/setup.sh
+++ b/overlays/git-helpers/setup.sh
@@ -31,6 +31,16 @@ else
     exit 1
 fi
 
+# Normalize GitHub credential helper for container paths
+# Example broken host value: !/home/linuxbrew/.linuxbrew/bin/gh auth git-credential
+if git config --global --get-all credential.helper 2>/dev/null | grep -Fxq '!/home/linuxbrew/.linuxbrew/bin/gh auth git-credential'; then
+    git config --global --fixed-value --unset-all credential.helper '!/home/linuxbrew/.linuxbrew/bin/gh auth git-credential' || true
+fi
+if ! git config --global --get-all credential.helper 2>/dev/null | grep -Fxq '!gh auth git-credential'; then
+    git config --global --add credential.helper '!gh auth git-credential'
+    echo "✓ GitHub credential helper configured for container gh"
+fi
+
 # Set up SSH permissions if .ssh directory exists
 if [ -d "$HOME/.ssh" ]; then
     chmod 700 "$HOME/.ssh"

--- a/tool/__tests__/git-helpers.test.ts
+++ b/tool/__tests__/git-helpers.test.ts
@@ -3,6 +3,10 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { execFileSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 function writeExecutable(filePath: string, content: string): void {
     fs.writeFileSync(filePath, content, 'utf-8');
@@ -11,70 +15,74 @@ function writeExecutable(filePath: string, content: string): void {
 
 describe('git-helpers setup', () => {
     it('replaces broken host gh credential helper path with container-safe gh helper', () => {
-        const repoRoot = path.join(__dirname, '..', '..');
-        const setupScript = path.join(repoRoot, 'overlays', 'git-helpers', 'setup.sh');
         const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'git-helpers-test-'));
-        const homeDir = path.join(tempRoot, 'home');
-        const binDir = path.join(tempRoot, 'bin');
-        fs.mkdirSync(homeDir, { recursive: true });
-        fs.mkdirSync(binDir, { recursive: true });
+        try {
+            const repoRoot = path.join(__dirname, '..', '..');
+            const setupScript = path.join(repoRoot, 'overlays', 'git-helpers', 'setup.sh');
+            const homeDir = path.join(tempRoot, 'home');
+            const binDir = path.join(tempRoot, 'bin');
+            fs.mkdirSync(homeDir, { recursive: true });
+            fs.mkdirSync(binDir, { recursive: true });
 
-        writeExecutable(
-            path.join(binDir, 'gh'),
-            `#!/bin/bash
+            writeExecutable(
+                path.join(binDir, 'gh'),
+                `#!/bin/bash
 if [ "$1" = "--version" ]; then
   echo "gh version test"
   exit 0
 fi
 exit 0
 `
-        );
+            );
 
-        writeExecutable(
-            path.join(binDir, 'git-lfs'),
-            `#!/bin/bash
+            writeExecutable(
+                path.join(binDir, 'git-lfs'),
+                `#!/bin/bash
 if [ "$1" = "version" ]; then
   echo "git-lfs/test"
   exit 0
 fi
 exit 0
 `
-        );
+            );
 
-        const env = {
-            ...process.env,
-            HOME: homeDir,
-            XDG_CONFIG_HOME: path.join(tempRoot, 'xdg-config'),
-            PATH: `${binDir}:${process.env.PATH ?? ''}`,
-            GIT_CONFIG_NOSYSTEM: '1',
-        };
+            const env = {
+                ...process.env,
+                HOME: homeDir,
+                XDG_CONFIG_HOME: path.join(tempRoot, 'xdg-config'),
+                PATH: `${binDir}:${process.env.PATH ?? ''}`,
+                GIT_CONFIG_NOSYSTEM: '1',
+            };
 
-        execFileSync(
-            'git',
-            [
-                'config',
-                '--global',
-                'credential.helper',
-                '!/home/linuxbrew/.linuxbrew/bin/gh auth git-credential',
-            ],
-            { env }
-        );
+            execFileSync(
+                'git',
+                [
+                    'config',
+                    '--global',
+                    'credential.helper',
+                    '!/home/linuxbrew/.linuxbrew/bin/gh auth git-credential',
+                ],
+                { env }
+            );
 
-        execFileSync('bash', [setupScript], { env, cwd: tempRoot, stdio: 'pipe' });
+            execFileSync('bash', [setupScript], { env, cwd: tempRoot, stdio: 'pipe' });
 
-        const helpers = execFileSync(
-            'git',
-            ['config', '--global', '--get-all', 'credential.helper'],
-            {
-                env,
-                encoding: 'utf-8',
-            }
-        )
-            .trim()
-            .split('\n')
-            .filter(Boolean);
+            const helpers = execFileSync(
+                'git',
+                ['config', '--global', '--get-all', 'credential.helper'],
+                {
+                    env,
+                    encoding: 'utf-8',
+                }
+            )
+                .trim()
+                .split('\n')
+                .filter(Boolean);
 
-        expect(helpers).toContain('!gh auth git-credential');
-        expect(helpers).not.toContain('!/home/linuxbrew/.linuxbrew/bin/gh auth git-credential');
+            expect(helpers).toContain('!gh auth git-credential');
+            expect(helpers).not.toContain('!/home/linuxbrew/.linuxbrew/bin/gh auth git-credential');
+        } finally {
+            fs.rmSync(tempRoot, { recursive: true, force: true });
+        }
     });
 });

--- a/tool/__tests__/git-helpers.test.ts
+++ b/tool/__tests__/git-helpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { execFileSync } from 'child_process';
+
+function writeExecutable(filePath: string, content: string): void {
+    fs.writeFileSync(filePath, content, 'utf-8');
+    fs.chmodSync(filePath, 0o755);
+}
+
+describe('git-helpers setup', () => {
+    it('replaces broken host gh credential helper path with container-safe gh helper', () => {
+        const repoRoot = path.join(__dirname, '..', '..');
+        const setupScript = path.join(repoRoot, 'overlays', 'git-helpers', 'setup.sh');
+        const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'git-helpers-test-'));
+        const homeDir = path.join(tempRoot, 'home');
+        const binDir = path.join(tempRoot, 'bin');
+        fs.mkdirSync(homeDir, { recursive: true });
+        fs.mkdirSync(binDir, { recursive: true });
+
+        writeExecutable(
+            path.join(binDir, 'gh'),
+            `#!/bin/bash
+if [ "$1" = "--version" ]; then
+  echo "gh version test"
+  exit 0
+fi
+exit 0
+`
+        );
+
+        writeExecutable(
+            path.join(binDir, 'git-lfs'),
+            `#!/bin/bash
+if [ "$1" = "version" ]; then
+  echo "git-lfs/test"
+  exit 0
+fi
+exit 0
+`
+        );
+
+        const env = {
+            ...process.env,
+            HOME: homeDir,
+            XDG_CONFIG_HOME: path.join(tempRoot, 'xdg-config'),
+            PATH: `${binDir}:${process.env.PATH ?? ''}`,
+            GIT_CONFIG_NOSYSTEM: '1',
+        };
+
+        execFileSync(
+            'git',
+            [
+                'config',
+                '--global',
+                'credential.helper',
+                '!/home/linuxbrew/.linuxbrew/bin/gh auth git-credential',
+            ],
+            { env }
+        );
+
+        execFileSync('bash', [setupScript], { env, cwd: tempRoot, stdio: 'pipe' });
+
+        const helpers = execFileSync(
+            'git',
+            ['config', '--global', '--get-all', 'credential.helper'],
+            {
+                env,
+                encoding: 'utf-8',
+            }
+        )
+            .trim()
+            .split('\n')
+            .filter(Boolean);
+
+        expect(helpers).toContain('!gh auth git-credential');
+        expect(helpers).not.toContain('!/home/linuxbrew/.linuxbrew/bin/gh auth git-credential');
+    });
+});


### PR DESCRIPTION
Introduce support for versioned private overlay and preset catalogs, improve onboarding with a focus on preset-first guidance, and align documentation with current workflows. Additionally, address issues with GitHub credential helper paths in container environments to ensure seamless `git push` operations.